### PR TITLE
Add support for customize "chatgpt" api base url and model lists

### DIFF
--- a/apps/desktop/src-tauri/src/app/conf.rs
+++ b/apps/desktop/src-tauri/src/app/conf.rs
@@ -22,6 +22,7 @@ pub_struct!(AppConf {
     editor_full_width: Option<bool>,
     editor_root_font_size: Option<u32>,
     editor_root_line_height: Option<String>,
+    extensions_chatgpt_apibase: Option<String>,
     extensions_chatgpt_apikey: Option<String>,
     autosave: Option<bool>,
     autosave_interval: Option<u32>,
@@ -44,6 +45,7 @@ impl AppConf {
             editor_root_line_height: Some("1.6".to_string()),
             autosave: Some(false),
             autosave_interval: Some(2000),
+            extensions_chatgpt_apibase: Some("https://api.openai.com/v1/chat/completions".to_string()),
             extensions_chatgpt_apikey: Some("".to_string()),
         }
     }
@@ -81,6 +83,9 @@ impl AppConf {
         }
         if oldconf.autosave_interval.is_some() {
             self.autosave_interval = oldconf.autosave_interval;
+        }
+        if oldconf.extensions_chatgpt_apibase.is_some() {
+            self.extensions_chatgpt_apibase = oldconf.extensions_chatgpt_apibase;
         }
         if oldconf.extensions_chatgpt_apikey.is_some() {
             self.extensions_chatgpt_apikey = oldconf.extensions_chatgpt_apikey;

--- a/apps/desktop/src-tauri/src/app/conf.rs
+++ b/apps/desktop/src-tauri/src/app/conf.rs
@@ -24,6 +24,7 @@ pub_struct!(AppConf {
     editor_root_line_height: Option<String>,
     extensions_chatgpt_apibase: Option<String>,
     extensions_chatgpt_apikey: Option<String>,
+    extensions_chatgpt_models: Option<String>,
     autosave: Option<bool>,
     autosave_interval: Option<u32>,
 });
@@ -46,6 +47,7 @@ impl AppConf {
             autosave: Some(false),
             autosave_interval: Some(2000),
             extensions_chatgpt_apibase: Some("https://api.openai.com/v1/chat/completions".to_string()),
+            extensions_chatgpt_models: Some("gpt-3.5-turbo, gpt-4-32k, gpt-4".to_string()),
             extensions_chatgpt_apikey: Some("".to_string()),
         }
     }
@@ -89,6 +91,9 @@ impl AppConf {
         }
         if oldconf.extensions_chatgpt_apikey.is_some() {
             self.extensions_chatgpt_apikey = oldconf.extensions_chatgpt_apikey;
+        }
+        if oldconf.extensions_chatgpt_models.is_some() {
+            self.extensions_chatgpt_models = oldconf.extensions_chatgpt_models;
         }
         self.write()
     }

--- a/apps/desktop/src/components/EditorArea/EditorAreaHeader.tsx
+++ b/apps/desktop/src/components/EditorArea/EditorAreaHeader.tsx
@@ -31,7 +31,7 @@ export const EditorAreaHeader = memo(() => {
     const content = getEditorContent(curFile?.id || '')
     const res = await addAppTask({
       title: 'ChatGPT: Retrieving article abstract',
-      promise: getPostSummary(content || '', settingData.extensions_chatgpt_apikey),
+      promise: getPostSummary(content || '',settingData.extensions_chatgpt_apibase, settingData.extensions_chatgpt_apikey),
     })
     if (res.status === 'done') {
       addNewMarkdownFileEdit({
@@ -58,7 +58,7 @@ ${res.result}
       const content = getEditorContent(curFile?.id || '')
       const res = await addAppTask({
         title: 'ChatGPT: Translating article',
-        promise: getPostTranslate(content || '', settingData.extensions_chatgpt_apikey, targetLang),
+        promise: getPostTranslate(content || '',settingData.extensions_chatgpt_apibase,  settingData.extensions_chatgpt_apikey, targetLang),
       })
 
       if (res.status === 'done') {

--- a/apps/desktop/src/extensions/chatgpt/api.ts
+++ b/apps/desktop/src/extensions/chatgpt/api.ts
@@ -1,4 +1,5 @@
 export async function callChatGptApi(
+  url: string,
   text: string,
   model: string,
   onStatus: (status: Status) => void,
@@ -8,7 +9,7 @@ export async function callChatGptApi(
     messages?: { role: string; content: string }[]
   },
 ): Promise<Status> {
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -32,7 +33,7 @@ export async function callChatGptApi(
     if (res.error.message.match(/You can retry/) && maxRetry > 0) {
       // Sometimes the API returns an error saying 'You can retry'. So we retry.
       onStatus({ status: 'pending', lastToken: `(Retrying ${maxRetry})` })
-      return await callChatGptApi(text, model, onStatus, maxRetry - 1, apiKey)
+      return await callChatGptApi(url, text, model, onStatus, maxRetry - 1, apiKey)
     }
     onStatus({ status: 'error', message: res.error.message })
     return { status: 'error', message: res.error.message }

--- a/apps/desktop/src/extensions/chatgpt/index.tsx
+++ b/apps/desktop/src/extensions/chatgpt/index.tsx
@@ -19,6 +19,7 @@ const ChatList: React.FC<ChatListProps> = (props) => {
     useChatGPTStore()
   const { settingData } = useAppSettingStore()
   const { curTheme } = useThemeStore()
+  const apiBase = settingData[SettingKeys.cahtgpt_url]
   const apiKey = settingData[SettingKeys.chatgpt]
   const [askInput, setAskInput] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
@@ -32,7 +33,7 @@ const ChatList: React.FC<ChatListProps> = (props) => {
   const handleSubmit = useCallback(() => {
     if (!apiKey) return
 
-    addChat(askInput, apiKey)
+    addChat(askInput, apiBase, apiKey)
     setAskInput('')
   }, [apiKey, addChat, askInput])
 

--- a/apps/desktop/src/extensions/chatgpt/index.tsx
+++ b/apps/desktop/src/extensions/chatgpt/index.tsx
@@ -15,11 +15,11 @@ import useAppSettingStore from '@/stores/useAppSettingStore'
 import { addNewMarkdownFileEdit } from '@/services/editor-file'
 
 const ChatList: React.FC<ChatListProps> = (props) => {
-  const { chatList, curGptModelIndex, gptModels, setCurGptModelIndex, addChat, delChat } =
+  const { chatList, curGptModelIndex, gptModels, setCurGptModelIndex, addChat, delChat, setModels } =
     useChatGPTStore()
   const { settingData } = useAppSettingStore()
   const { curTheme } = useThemeStore()
-  const apiBase = settingData[SettingKeys.cahtgpt_url]
+  const apiBase = settingData[SettingKeys.chatgpt_url]
   const apiKey = settingData[SettingKeys.chatgpt]
   const [askInput, setAskInput] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
@@ -28,6 +28,9 @@ const ChatList: React.FC<ChatListProps> = (props) => {
     if (listRef.current) {
       listRef.current.scrollTop = listRef.current.scrollHeight
     }
+
+    const newModels = settingData[SettingKeys.chatgpt_models].split(',').map((model: string) => model.trim())
+    setModels(newModels)
   }, [chatList.length])
 
   const handleSubmit = useCallback(() => {

--- a/apps/desktop/src/extensions/chatgpt/useChatGPTStore.ts
+++ b/apps/desktop/src/extensions/chatgpt/useChatGPTStore.ts
@@ -7,7 +7,7 @@ const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
   curGptModelIndex: 0,
 
 
-  gptModels: ['gpt-3.5-turbo', 'gpt-4-32k', 'gpt-4', 'THUDM/glm-4-9b-chat', 'qwen2.5:7b-instruct-q4_K_M'],
+  gptModels: ['gpt-3.5-turbo', 'gpt-4-32k', 'gpt-4'],
   // gptModels: settingData.extensions_chatgpt_models,
 
   chatList: [],
@@ -112,6 +112,12 @@ const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
     })
   },
 
+  setModels:(models: string[]) => {
+    set((state) => {
+      return { ...state, gptModels: models }
+    })
+  }
+
 }))
 
 type ChatStatus = 'pending' | 'done' | 'error'
@@ -135,6 +141,7 @@ interface ChatGPTStore {
   addChatQuestion: (question: string) => ChatGPTHistory
   addChatAnswer: (id: string, answer: string) => void
   delChat: (id: string) => void
+  setModels:(models: string[]) => void
 }
 
 export default useChatGPTStore

--- a/apps/desktop/src/extensions/chatgpt/useChatGPTStore.ts
+++ b/apps/desktop/src/extensions/chatgpt/useChatGPTStore.ts
@@ -6,7 +6,9 @@ import { callChatGptApi } from '@/extensions/chatgpt/api'
 const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
   curGptModelIndex: 0,
 
-  gptModels: ['gpt-3.5-turbo', 'gpt-4-32k', 'gpt-4'],
+
+  gptModels: ['gpt-3.5-turbo', 'gpt-4-32k', 'gpt-4', 'THUDM/glm-4-9b-chat', 'qwen2.5:7b-instruct-q4_K_M'],
+  // gptModels: settingData.extensions_chatgpt_models,
 
   chatList: [],
 
@@ -27,11 +29,12 @@ const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
     })
   },
 
-  addChat: (question: string, apiKey: string) => {
+  addChat: (question: string,url:string, apiKey: string) => {
     const curStore = get()
     const { gptModels, curGptModelIndex } = curStore
     const chat = curStore.addChatQuestion(question)
     callChatGptApi(
+      url,
       question,
       gptModels[curGptModelIndex],
       (res) => {
@@ -44,9 +47,9 @@ const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
     return chat
   },
 
-  getPostSummary: async (text: string, apiKey: string) => {
+  getPostSummary: async (text: string,url:string, apiKey: string) => {
     const { gptModels, curGptModelIndex } = get()
-    const res = await callChatGptApi(text, gptModels[curGptModelIndex], () => {}, 5, apiKey, {
+    const res = await callChatGptApi(url, text, gptModels[curGptModelIndex], () => {}, 5, apiKey, {
       messages: [
         {
           role: 'system',
@@ -60,9 +63,9 @@ const useChatGPTStore = create<ChatGPTStore>((set, get) => ({
     return res
   },
 
-  getPostTranslate: async (text: string, apiKey: string, targetLang: string) => {
+  getPostTranslate: async (text: string,url:string, apiKey: string, targetLang: string) => {
     const { gptModels, curGptModelIndex } = get()
-    const res = await callChatGptApi(text, gptModels[curGptModelIndex], () => {}, 5, apiKey, {
+    const res = await callChatGptApi(url,text, gptModels[curGptModelIndex], () => {}, 5, apiKey, {
       messages: [
         {
           role: 'system',
@@ -126,9 +129,9 @@ interface ChatGPTStore {
   curGptModelIndex: number
   setCurGptModelIndex: (index: number) => void
   setChatStatus: (id: string, status: ChatStatus) => void
-  addChat: (question: string, apiKey: string) => ChatGPTHistory
-  getPostSummary: (text: string, apiKey: string) => Promise<Status>
-  getPostTranslate: (text: string, apiKey: string, targetLang: string) => Promise<Status>
+  addChat: (question: string,url:string, apiKey: string) => ChatGPTHistory
+  getPostSummary: (text: string,url:string, apiKey: string) => Promise<Status>
+  getPostTranslate: (text: string,url:string, apiKey: string, targetLang: string) => Promise<Status>
   addChatQuestion: (question: string) => ChatGPTHistory
   addChatAnswer: (id: string, answer: string) => void
   delChat: (id: string) => void

--- a/apps/desktop/src/router/Setting/settingMap.ts
+++ b/apps/desktop/src/router/Setting/settingMap.ts
@@ -2,7 +2,8 @@ import SettingSchema from './settingSchema.json'
 export enum SettingKeys {
   language = 'language',
   chatgpt = 'extensions_chatgpt_apikey',
-  cahtgpt_url = 'extensions_chatgpt_apibase'
+  chatgpt_url = 'extensions_chatgpt_apibase',
+  chatgpt_models = 'extensions_chatgpt_models'
 }
 
 export default SettingSchema

--- a/apps/desktop/src/router/Setting/settingMap.ts
+++ b/apps/desktop/src/router/Setting/settingMap.ts
@@ -2,6 +2,7 @@ import SettingSchema from './settingSchema.json'
 export enum SettingKeys {
   language = 'language',
   chatgpt = 'extensions_chatgpt_apikey',
+  cahtgpt_url = 'extensions_chatgpt_apibase'
 }
 
 export default SettingSchema

--- a/apps/desktop/src/router/Setting/settingSchema.json
+++ b/apps/desktop/src/router/Setting/settingSchema.json
@@ -110,6 +110,16 @@
     "i18nKey": "settings.extensions.label",
     "ChatGPT": {
       "i18nKey": "settings.extensions.ChatGPT.label",
+      "ApiBase": {
+        "key": "extensions_chatgpt_apibase",
+        "type": "input",
+        "title": {
+          "i18nKey": "settings.extensions.ChatGPT.api_base.label"
+        },
+        "desc": {
+          "i18nKey": "settings.extensions.ChatGPT.api_base.desc"
+        }
+      },
       "ApiKey": {
         "key": "extensions_chatgpt_apikey",
         "type": "input",

--- a/apps/desktop/src/router/Setting/settingSchema.json
+++ b/apps/desktop/src/router/Setting/settingSchema.json
@@ -129,6 +129,16 @@
         "desc": {
           "i18nKey": "settings.extensions.ChatGPT.api_key.desc"
         }
+      },
+      "models":{
+        "key":"extensions_chatgpt_models",
+        "type":"input",
+        "title":{
+          "i18nKey":"settings.extensions.ChatGPT.models.label"
+          },
+          "desc":{
+            "i18nKey":"settings.extensions.ChatGPT.models.desc"
+            }
       }
     }
   },

--- a/apps/web/.contentlayer/generated/index.mjs
+++ b/apps/web/.contentlayer/generated/index.mjs
@@ -4,8 +4,8 @@ export { isType } from 'contentlayer/client'
 
 // NOTE During development Contentlayer imports from `.mjs` files to improve HMR speeds.
 // During (production) builds Contentlayer it imports from `.json` files to improve build performance.
-import { allPosts } from './Post/_index.mjs'
-import { allMarkdowns } from './Markdown/_index.mjs'
+import allPosts from './Post/_index.json' assert { type: 'json' }
+import allMarkdowns from './Markdown/_index.json' assert { type: 'json' }
 
 export { allPosts, allMarkdowns }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -156,6 +156,10 @@
       "label": "Extensions",
       "ChatGPT": {
         "label": "ChatGPT",
+        "api_base": {
+          "label": "API Base",
+          "desc": "API Base for ChatGPT."
+        },
         "api_key": {
           "label": "API Key",
           "desc": "API key for ChatGPT."

--- a/locales/en.json
+++ b/locales/en.json
@@ -163,6 +163,10 @@
         "api_key": {
           "label": "API Key",
           "desc": "API key for ChatGPT."
+        },
+        "models":{
+          "label": "Models",
+          "desc":  "A model list separated by commas, default is \"gpt-3.5-turbo, gpt-4-32k, gpt-4\""
         }
       }
     }

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -129,6 +129,10 @@
       "label": "Extensions",
       "ChatGPT": {
         "label": "ChatGPT",
+        "api_base": {
+          "label": "API Base",
+          "desc": "API Base for ChatGPT."
+        },
         "api_key": {
           "label": "clé API",
           "desc": "clé API pour ChatGPT."

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -136,6 +136,10 @@
         "api_key": {
           "label": "clé API",
           "desc": "clé API pour ChatGPT."
+        },
+        "models":{
+          "label": "Models",
+          "desc":  "A model list separated by commas, default is \"gpt-3.5-turbo, gpt-4-32k, gpt-4\""
         }
       }
     }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -162,6 +162,10 @@
         "api_key": {
           "label": "API Key",
           "desc": "ChatGPT 的 API key。"
+        },
+        "models":{
+          "label": "模型列表",
+          "desc":  "模型列表, 用逗号分割模型名称, 默认为\"gpt-3.5-turbo, gpt-4-32k, gpt-4\""
         }
       }
     }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -155,6 +155,10 @@
       "label": "扩展",
       "ChatGPT": {
         "label": "ChatGPT",
+        "api_base": {
+          "label": "API Base",
+          "desc": " ChatGPT 的 API 地址."
+        },
         "api_key": {
           "label": "API Key",
           "desc": "ChatGPT 的 API key。"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

I hope to utilize APIs other than those provided by OpenAI (In my case is Ollama). Notice that many llm provider provide an OpenAI compatible API. It's commendable that one can customize API base url in the setting page. To enable models from other api source one needs to provide a list of available models. Base on these point, I add two terms in configuration
- apiBase, for custom api base url support
- models, for custom available models

## Many need Help

I don't speak French, so helps in locales for new content in setting page. 

## How did you test this change?

- changes in setting page
![changesInSettingPage](https://github.com/user-attachments/assets/659b68e3-e01c-43fe-bb66-ce5a12a915e6)

- changes in chatgpt extension when modified default models
![changesInChatgptExtensionWhenModifiedDefaultModels](https://github.com/user-attachments/assets/63b5bdec-de15-4dff-9f56-28213ba63b90)

- chat through local ollama api
![chatThroughLocalOllamaApi](https://github.com/user-attachments/assets/d0e46b32-63a8-4694-bf99-74c9012cc055)
