### PR TITLE
fix: use xdg standards

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = "0.3.18"
 window-vibrancy = "0.5.0"
 dotenv = "0.15.0"
 trash = "5.2.2"
+etcetera ="0.10.0"
 
 [dependencies.tauri-plugin-notification]
 version = "2.2.2"


### PR DESCRIPTION
-   [X] I read the contributing guide
-   [X] I agree to follow the code of conduct

## Summary

The way things are right now (at least on my Linux machine):

-  `~/.markflowy/` - Main config directory from app_root() in conf.rs
-  `~/.config/com.drl990114.markflowy/` and `~/.local/share/com.drl990114.markflowy/` - Created by Tauri

On Linux after clean install, config files should look like this;
```
❯ ls .config/markflowy 
keybord_map.json   opened_cache.json
                                                                        
❯ ls .local/share/markflowy 
hsts-storage.sqlite
                                                                      
❯ ls .cache/markflowy 
CacheStorage/  WebKitCache/

❯ ls .config/com.drl990114.markflowy

❯ ls .local/share/com.drl990114.markflowy 
databases/  localstorage/  mediakeys/  storage/
```

next step would be to move `~/.config/com.drl990114.markflowy` to use ` ~/.config/markflowy` and to move` .local/share/com.drl990114.markflowy` to use `~/.local/share/markflowy`

And to assure backward compatibility if ~/.markflowy exist it will keep using it !


On Windows, the behavior should be the same, as I don't have any idea about file structure in windows work, if someone with experience there want to chime in, would be happy to implement what ever standard they use


## How did you test this change?

Make sure to move the current config file ! `.markflowy` to `markflowy.bck` first before the running the app ! 