### PR TITLE
fix: implement language switching in select setting

### DIFF
--- a/apps/desktop/src/router/Setting/component/SettingItems/Select.tsx
+++ b/apps/desktop/src/router/Setting/component/SettingItems/Select.tsx
@@ -5,6 +5,7 @@ import Autocomplete from '@mui/material/Autocomplete'
 import type { SettingItemProps } from '.'
 import { SettingItemContainer } from './Container'
 import { SettingLabel } from './Label'
+import { changeLng } from '@/i18n'
 
 const SelectSettingItem: React.FC<SettingItemProps<Setting.SelectSettingItem>> = (props) => {
   const { item } = props
@@ -30,6 +31,9 @@ const SelectSettingItem: React.FC<SettingItemProps<Setting.SelectSettingItem>> =
           e.stopPropagation()
           if (!v) return
           appSettingService.writeSettingData(item, v.value)
+          if (item.key === 'language') {
+            changeLng(v.value)
+          }
         }}
         getOptionKey={(option) => option.value}
         sx={{ width: '220px' }}


### PR DESCRIPTION
Fix the issue where language selector does not switch the UI language.

Cause: The changeLng function is not called in SelectSettingItem.

Solution: Add a condition in onChange to call changeLng(v.value) when item.key === 'language'.

Tested: The UI language now switches immediately after selection and persists after page refresh.