### PR TITLE
Fix: Prevent drag and focus conflicts during rename

### DIFF
--- a/apps/desktop/src/components/FileTree/FileNode.tsx
+++ b/apps/desktop/src/components/FileTree/FileNode.tsx
@@ -273,12 +273,21 @@ function FileNode({
         })
       }}
       onClick={(e) => {
+        if (isPending) {
+          e.stopPropagation()
+          return
+        }
         if (e.shiftKey) {
           return
         }
         node.isInternal && node.toggle()
       }}
-      ref={dragHandle}
+      onMouseUp={(e) => {
+        if (isPending) {
+          e.stopPropagation()
+        }
+      }}
+      ref={isPending ? null : dragHandle}
     >
       <div style={{ display: 'flex', padding: '0 6px', width: '100%', boxSizing: 'border-box' }}>
         <div className='indentLines'>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

修复文件树重命名时的交互冲突问题：

1. 在重命名输入框中按住鼠标左键拖动选中文本时，会触发文件行的拖拽操作，导致无法正常选中文本。
2. 修复第一个问题后，在重命名过程中，如果鼠标在输入框内按下并选中文本，移动到输入框外松开时，有可能会导致输入框失去焦点，触发是否保存重命名的弹窗。

解决：
- 在节点处于 `isPending` 状态时，禁用该行的拖拽功能
- 在编辑状态下，阻止 `onClick` 和 `onMouseUp` 事件冒泡，防止父级容器的聚焦逻辑干扰输入框

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

1. **文本选择测试**：右键点击文件，选择"重命名"。在输入框内按住鼠标左键，拖动选中文本。文本被正常选中，文件行不会被拖拽。
2. **鼠标释放测试**：在重命名输入框中按住鼠标左键选中文本。将光标移动到输入框外（但保持在文件行背景内）。松开鼠标左键。多次测试，输入框永远保持焦点，不会触发保存修改弹窗。

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
