### PR TITLE
feat: add middle-click functionality to close tabs in EditorAreaTabs

### DIFF
--- a/apps/desktop/src/components/EditorArea/EditorAreaTabs.tsx
+++ b/apps/desktop/src/components/EditorArea/EditorAreaTabs.tsx
@@ -121,14 +121,37 @@ const EditorAreaTabs = memo(() => {
   return (
     <Container>
       <div className='tab-control'>
-        <MfIconButton icon='ri-arrow-left-line' size='small' rounded='smooth' onClick={() => moveActiveTab('left')}/>
-        <MfIconButton icon='ri-arrow-right-line' size='small' rounded='smooth' onClick={() => moveActiveTab('right')}/>
+        <MfIconButton icon='ri-arrow-left-line' size='small' rounded='smooth' onClick={() => moveActiveTab('left')} />
+        <MfIconButton icon='ri-arrow-right-line' size='small' rounded='smooth' onClick={() => moveActiveTab('right')} />
       </div>
       <div className='tab-items' ref={htmlRef}>
         {opened.map((id) => {
           const file = getFileObject(id) as IFile
           const active = activeId === id
           const editorState = idStateMap.get(id)
+
+          const handleMiddleClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+            // 鼠标中键点击关闭标签页
+            if (e.button !== 1) return
+            e.stopPropagation()
+            e.preventDefault()
+            if (
+              checkUnsavedFiles({
+                fileIds: [id],
+                onSaveAndClose: async () => {
+                  const saveHandler = getSaveOpenedEditorEntries(id)
+                  await saveHandler?.()
+                  close(e, id)
+                },
+                onUnsavedAndClose: () => {
+                  close(e, id)
+                },
+              }) > 0
+            ) {
+              return
+            }
+            close(e, id)
+          }
 
           const handleContextMenu = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
             e.stopPropagation()
@@ -219,6 +242,7 @@ const EditorAreaTabs = memo(() => {
                 onClick={() => onSelectItem(file.id)}
                 key={id}
                 onContextMenu={handleContextMenu}
+                onMouseDown={handleMiddleClick}
               >
                 <span
                   style={{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
添加鼠标中键点击关闭标签页的功能。
动机：目前关闭标签页只能通过点击关闭按钮或右键菜单，这与大多数现代浏览器和代码编辑器（如 Chrome、VS Code）的交互习惯不一致。用户习惯使用鼠标中键快速关闭标签页，添加此功能可以提升用户体验和操作效率。
改动内容：
在 EditorAreaTabs.tsx 中为 TabItem 组件添加 onMouseDown 事件监听
当检测到鼠标中键点击（button === 1）时触发关闭逻辑
关闭时会检查文件是否有未保存的更改，与现有的关闭逻辑保持一致

## How did you test this change?
编译执行后正常测试
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
