### PR TITLE
style: improve formatting in EditorAreaTabs and FileNode components

### DIFF
--- a/apps/desktop/src/components/EditorArea/EditorAreaTabs.tsx
+++ b/apps/desktop/src/components/EditorArea/EditorAreaTabs.tsx
@@ -121,8 +121,8 @@ const EditorAreaTabs = memo(() => {
   return (
     <Container>
       <div className='tab-control'>
-        <MfIconButton icon='ri-arrow-left-line' size='small' rounded='smooth' onClick={() => moveActiveTab('left')}/>
-        <MfIconButton icon='ri-arrow-right-line' size='small' rounded='smooth' onClick={() => moveActiveTab('right')}/>
+        <MfIconButton icon='ri-arrow-left-line' size='small' rounded='smooth' onClick={() => moveActiveTab('left')} />
+        <MfIconButton icon='ri-arrow-right-line' size='small' rounded='smooth' onClick={() => moveActiveTab('right')} />
       </div>
       <div className='tab-items' ref={htmlRef}>
         {opened.map((id) => {

--- a/apps/desktop/src/components/FileTree/FileNode.tsx
+++ b/apps/desktop/src/components/FileTree/FileNode.tsx
@@ -1,9 +1,9 @@
 import {
-    createFile,
-    getFileNameFromPath,
-    readDirectory,
-    updateFile,
-    type IFile,
+  createFile,
+  getFileNameFromPath,
+  readDirectory,
+  updateFile,
+  type IFile,
 } from '@/helper/filesys'
 import { useEditorStore } from '@/stores'
 import NiceModal from '@ebay/nice-modal-react'
@@ -353,7 +353,7 @@ function FileNode({
               alignItems: 'center',
             }}
           >
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, display: 'flex', alignItems: 'center', overflow: 'hidden', minWidth: 0 }}>
               {node.data?.kind === 'dir' ? (
                 <i
                   className={`${node.isOpen ? 'ri-folder-5-fill' : 'ri-folder-3-fill'} file-icon`}
@@ -364,6 +364,8 @@ function FileNode({
               <span
                 style={{
                   whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
                 }}
               >
                 {node.data.name}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary
修复文件树在调整宽度时图标和文件名换行的问题。
问题描述：当用户拖动调整文件树面板宽度时，图标和文件名可能会换行，导致文件名位置不稳定，视觉上出现"跳动"的现象。
解决方案：

- 为包含图标和文件名的容器添加 display: flex 布局，确保图标和文件名始终在同一行
- 添加 overflow: hidden 和 minWidth: 0 使 flex 子元素能够正确收缩
- 为文件名添加 text-overflow: ellipsis，当文件名过长时显示省略号
<img width="291" height="328" alt="image" src="https://github.com/user-attachments/assets/1cd4dc5e-77ae-410e-bf23-5b4311eb598d" />

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
