### PR TITLE
feat: add path variable support for image upload and paste functionality

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -334,7 +334,7 @@
         },
         "paste_image_save_relative_path_rule": {
           "label": "Path Rules",
-          "desc": "${documentPath} refers to the parent folder path of the file you are currently editing. When you paste the picture, the picture will be saved to the path relative to the current file."
+          "desc": "Supported variables: ${documentPath} (parent folder path of current file), ${fileName} (current file name without extension). Example: ${documentPath}/photo/${fileName}"
         }
       },
       "upload_img": {
@@ -359,7 +359,7 @@
         },
         "upload_image_save_relative_path_rule": {
           "label": "Path Rules",
-          "desc": "${documentPath} refers to the parent folder path of the file you are currently editing. When uploading an image, the image will be saved to the path relative to the current file."
+          "desc": "Supported variables: ${documentPath} (parent folder path of current file), ${fileName} (current file name without extension). Example: ${documentPath}/photo/${fileName}"
         }
       },
       "desc": "Configuring image processing and upload, including pasting images, saving paths and behavior settings for uploading image files."

--- a/locales/es.json
+++ b/locales/es.json
@@ -302,7 +302,7 @@
         },
         "paste_image_save_relative_path_rule": {
           "label": "Reglas de ruta",
-          "desc": "$ {DocumentPath} se refiere a la ruta de la carpeta superior del archivo que está editando actualmente. Al \"pegar una imagen, la imagen se guardará en la ruta relativa al archivo actual."
+          "desc": "Variables soportadas: ${documentPath} (ruta de la carpeta padre del archivo actual), ${fileName} (nombre del archivo actual sin extensión). Ejemplo: ${documentPath}/photo/${fileName}"
         }
       },
       "upload_img": {
@@ -327,7 +327,7 @@
         },
         "upload_image_save_relative_path_rule": {
           "label": "Reglas de ruta",
-          "desc": "$ {DocumentPath} se refiere a la ruta de la carpeta superior del archivo que está editando actualmente. Al \"cargar una imagen, la imagen se guardará en la ruta relativa al archivo actual."
+          "desc": "Variables soportadas: ${documentPath} (ruta de la carpeta padre del archivo actual), ${fileName} (nombre del archivo actual sin extensión). Ejemplo: ${documentPath}/photo/${fileName}"
         }
       },
       "desc": "Configuración de procesamiento y carga de imágenes, incluida la ruta de guardado y la configuración de comportamiento para pegar imágenes, cargar archivos de imágenes."

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -299,7 +299,7 @@
         },
         "paste_image_save_relative_path_rule": {
           "label": "Règles de chemin",
-          "desc": "$ {DocumentPath} fait référence au chemin du dossier supérieur du fichier que vous éditez actuellement. Lorsque vous \"collez l'image, l'image sera enregistrée au chemin par rapport au fichier actuel."
+          "desc": "Variables supportées: ${documentPath} (chemin du dossier parent du fichier actuel), ${fileName} (nom du fichier actuel sans extension). Exemple: ${documentPath}/photo/${fileName}"
         }
       },
       "upload_img": {
@@ -324,7 +324,7 @@
         },
         "upload_image_save_relative_path_rule": {
           "label": "Règles de chemin",
-          "desc": "$ {DocumentPath} fait référence au chemin du dossier supérieur dans lequel vous éditez actuellement le fichier. Lorsque \"Téléchargez une image, l'image sera enregistrée dans le chemin par rapport au fichier actuel."
+          "desc": "Variables supportées: ${documentPath} (chemin du dossier parent du fichier actuel), ${fileName} (nom du fichier actuel sans extension). Exemple: ${documentPath}/photo/${fileName}"
         }
       },
       "desc": "Configuration du traitement d'image et du téléchargement, y compris les paramètres de chemin d'enregistrement et de comportement pour coller des images, télécharger des fichiers d'image."

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -307,7 +307,7 @@
         },
         "paste_image_save_relative_path_rule": {
           "label": "パスルール",
-          "desc": "$ {DocumentPath} は、あなたが現在編集しているファイルの上位フォルダパスで、「画像を貼り付けると、画像は現在のファイルを基準にしたパスに保存されます。"
+          "desc": "サポートされる変数：${documentPath}（現在のファイルの親フォルダパス）、${fileName}（拡張子なしの現在のファイル名）。例：${documentPath}/photo/${fileName}"
         }
       },
       "upload_img": {
@@ -332,7 +332,7 @@
         },
         "upload_image_save_relative_path_rule": {
           "label": "パスルール",
-          "desc": "$ {DocumentPath} は、あなたが現在編集しているファイルの上位フォルダパスで、「画像をアップロードすると、画像は現在のファイルを基準にしたパスに保存されます。"
+          "desc": "サポートされる変数：${documentPath}（現在のファイルの親フォルダパス）、${fileName}（拡張子なしの現在のファイル名）。例：${documentPath}/photo/${fileName}"
         }
       },
       "desc": "画像処理とアップロードの設定には、画像の貼り付け、画像ファイルの保存パスと動作設定が含まれます。"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -271,7 +271,7 @@
         },
         "paste_image_save_relative_path_rule": {
           "label": "路径规则",
-          "desc": "${documentPath} 是指你当前编辑文件的上级文件夹路径，当“粘贴图片时，图片将保存到相对于当前文件的路径。"
+          "desc": "支持变量：${documentPath}（当前文件所在文件夹路径）、${fileName}（当前文件名，不含扩展名）。例如：${documentPath}/photo/${fileName}"
         }
       },
       "upload_img": {
@@ -296,7 +296,7 @@
         },
         "upload_image_save_relative_path_rule": {
           "label": "路径规则",
-          "desc": "${documentPath} 是指你当前编辑文件的上级文件夹路径，当“上传图片时，图片将保存到相对于当前文件的路径。"
+          "desc": "支持变量：${documentPath}（当前文件所在文件夹路径）、${fileName}（当前文件名，不含扩展名）。例如：${documentPath}/photo/${fileName}"
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->
#1002 
<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary
为图片保存路径规则添加 ${fileName} 变量支持，允许用户将图片保存到以当前文档名称命名的文件夹中。
新增功能：

- 新增 ${fileName} 变量，表示当前文档的文件名（不含扩展名）
- 用户可以配置类似 ${documentPath}/photo/${fileName} 的路径规则，将图片保存到与文档同名的文件夹中

修复问题：

- 修复当 fileFolderPath 为空时，路径回退到工作区根目录
- 修复路径规则以 . 开头时的处理问题
- 修复 UI 前缀显示与实际存储值不一致导致的路径计算错误

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
<img width="745" height="273" alt="image" src="https://github.com/user-attachments/assets/8c2a0d2b-b96e-4bd8-91f7-b2aa464aeee0" />
<img width="279" height="144" alt="image" src="https://github.com/user-attachments/assets/5c926980-f488-438a-8060-2f2a4edba4a3" />




<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->
