### PR TITLE
fix: replace unwrap() with proper error handling in setup.rs

### DIFF
--- a/apps/desktop/src-tauri/src/setup.rs
+++ b/apps/desktop/src-tauri/src/setup.rs
@@ -41,8 +41,8 @@ pub fn init(app_handle: AppHandle, opened_urls: String) -> Result<(), Box<dyn st
         main_win = main_win.title_bar_style(TitleBarStyle::Transparent);
     }
 
-    let window = main_win.build().unwrap();
-    
+    let window = main_win.build()?;
+
     // 将初始窗口添加到全局窗口实例缓存中
     let window_label = window.label().to_string();
     let workspace_path = if !opened_urls.is_empty() {
@@ -50,13 +50,14 @@ pub fn init(app_handle: AppHandle, opened_urls: String) -> Result<(), Box<dyn st
     } else {
         "".to_string()
     };
-    
+
     // 存储窗口实例信息到全局缓存
     if !workspace_path.is_empty() {
         use std::path::PathBuf;
         use crate::WINDOW_INSTANCES;
-        
-        let mut instances = WINDOW_INSTANCES.lock().unwrap();
+
+        let mut instances = WINDOW_INSTANCES.lock()
+            .map_err(|e| format!("Failed to lock window instances: {}", e))?;
         instances.insert(window_label, PathBuf::from(workspace_path));
     }
 


### PR DESCRIPTION
## Summary

Two `.unwrap()` calls in `setup.rs` could cause the application to panic during startup.

## Changes

- `main_win.build().unwrap()` → `main_win.build()?` — propagates window creation errors up the call stack instead of panicking. Window creation can fail due to graphics driver issues, insufficient resources, etc.
- `WINDOW_INSTANCES.lock().unwrap()` → `.lock().map_err(...)` — handles mutex poisoning gracefully (which can occur if another thread panicked while holding the lock).

## Impact

Application will no longer panic on startup if window creation fails or if the global mutex is poisoned. Instead, errors are properly returned and can be handled by the caller.

## Test plan

- [ ] Verify application starts normally
- [ ] Verify deep-link URL handling still works
- [ ] Verify window focus behavior on reactivation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)