### PR TITLE
feat: add shortcut to toggle source code and WYSIWYG

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,6 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/AdySnowflake">
-            <img src="https://avatars.githubusercontent.com/u/163967164?v=4" width="90;" alt="AdySnowflake"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/hobostay">
             <img src="https://avatars.githubusercontent.com/u/110803307?v=4" width="90;" alt="hobostay"/>
             <br />
@@ -142,10 +135,10 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/SamDc73">
-            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
+        <a href="https://github.com/AdySnowflake">
+            <img src="https://avatars.githubusercontent.com/u/163967164?v=4" width="90;" alt="AdySnowflake"/>
             <br />
-            <sub><b>Husam Alshehadat</b></sub>
+            <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
@@ -153,6 +146,13 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
             <img src="https://avatars.githubusercontent.com/u/99468824?v=4" width="90;" alt="KiraKiraAyu"/>
             <br />
             <sub><b>Lysastriel</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/SamDc73">
+            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
+            <br />
+            <sub><b>Husam Alshehadat</b></sub>
         </a>
     </td>
     <td align="center">

--- a/apps/desktop/src-tauri/src/app/keybindings.rs
+++ b/apps/desktop/src-tauri/src/app/keybindings.rs
@@ -69,6 +69,15 @@ impl Keybindings {
                 "always".to_string(),
             ),
             KeybindingInfo::new(
+                "app_toggleEditorType".to_string(),
+                vec![
+                    "CommandOrCtrl".to_string(),
+                    "Shift".to_string(),
+                    "m".to_string(),
+                ],
+                "editor_focus".to_string(),
+            ),
+            KeybindingInfo::new(
                 "editor_copy".to_string(),
                 vec!["CommandOrCtrl".to_string(), "c".to_string()],
                 "editor_focus".to_string(),

--- a/apps/desktop/src/components/EditorArea/TextEditor.tsx
+++ b/apps/desktop/src/components/EditorArea/TextEditor.tsx
@@ -25,7 +25,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { save } from '@tauri-apps/plugin-dialog'
 import classNames from 'classnames'
 import html2canvas from 'html2canvas'
-import { debounce, DebouncedFunc } from 'lodash'
+import { debounce, DebouncedFunc, throttle } from 'lodash'
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMount, useUnmount } from 'react-use'
@@ -53,6 +53,7 @@ type SaveHandlerParams = {
    */
   active?: boolean
   onSuccess?: () => void
+  onFinally?: () => void
 }
 
 enum TextEditorStatus {
@@ -140,22 +141,40 @@ function TextEditor(props: TextEditorProps) {
 
   const saveHandler = useCallback(
     async (params: SaveHandlerParams = {}) => {
-      const { onSuccess } = params
-      if (!active && !params.active) return
+      const { onSuccess, onFinally } = params
+      const runFinally = () => {
+        onFinally?.()
+      }
+      const runSuccess = () => {
+        try {
+          onSuccess?.()
+        } finally {
+          runFinally()
+        }
+      }
+
+      if (!active && !params.active) {
+        runFinally()
+        return
+      }
       const curFile = getFileObject(id)
-      if (!curFile) return
+      if (!curFile) {
+        runFinally()
+        return
+      }
 
       const { idStateMap, setIdStateMap } = useEditorStateStore.getState()
 
       const curEditorState = idStateMap.get(curFile.id)
 
       if (!curEditorState?.hasUnsavedChanges) {
-        onSuccess?.()
+        runSuccess()
         return
       }
 
       if (!editorContextRef.current?.state.doc && !curFile.content) {
         // Unexpected
+        runFinally()
         return
       }
 
@@ -168,6 +187,7 @@ function TextEditor(props: TextEditorProps) {
       try {
         if (!curFile.path) {
           if (noFileSaveingRef.current === true) {
+            runFinally()
             return
           }
 
@@ -179,7 +199,10 @@ function TextEditor(props: TextEditorProps) {
             .then((path) => {
               noFileSaveingRef.current = false
 
-              if (path === null) return
+              if (path === null) {
+                runFinally()
+                return
+              }
               const filename = getFileNameFromPath(path)
               updateFileObject(curFile.id, { ...curFile, path, name: filename })
               insertNodeToFolderData({
@@ -191,11 +214,15 @@ function TextEditor(props: TextEditorProps) {
               invoke<FileSysResult>('write_file', { filePath: path, content: fileContent }).then(
                 (res) => {
                   if (res.code !== FileResultCode.Success) {
+                    runFinally()
                     return toast.error(res.content)
                   }
-                  onSuccess?.()
+                  runSuccess()
                 },
-              )
+              ).catch((error) => {
+                toast.error(String(error))
+                runFinally()
+              })
               setIdStateMap(curFile.id, {
                 hasUnsavedChanges: false,
               })
@@ -203,6 +230,7 @@ function TextEditor(props: TextEditorProps) {
             .catch((error) => {
               noFileSaveingRef.current = false
               toast.error(String(error))
+              runFinally()
             })
         } else {
           invoke<FileSysResult>('write_file', {
@@ -210,10 +238,14 @@ function TextEditor(props: TextEditorProps) {
             content: fileContent,
           }).then((res) => {
             if (res.code !== FileResultCode.Success) {
+              runFinally()
               return toast.error(res.content)
             }
             setContent(fileContent)
-            onSuccess?.()
+            runSuccess()
+          }).catch((error) => {
+            toast.error(String(error))
+            runFinally()
           })
 
           setIdStateMap(curFile.id, {
@@ -222,6 +254,7 @@ function TextEditor(props: TextEditorProps) {
         }
       } catch (error) {
         toast.error(String(error))
+        runFinally()
       }
     },
     [active, id, delegate, t, insertNodeToFolderData],
@@ -268,13 +301,20 @@ function TextEditor(props: TextEditorProps) {
     [active, id],
   )
 
+  const editorTypeSwitchingRef = useRef(false)
+
   useEffect(() => {
-    const cb = async (payload: EditorViewType) => {
+    const cb = throttle((payload: EditorViewType) => {
       if (active) {
+        if (editorTypeSwitchingRef.current) {
+          return
+        }
+
         if (editorRef.current?.getType() === payload) {
           return
         }
 
+        editorTypeSwitchingRef.current = true
         bus.emit(EVENT.app_save, {
           onSuccess: () => {
             if (payload === EditorViewType.SOURCECODE) {
@@ -304,13 +344,17 @@ function TextEditor(props: TextEditorProps) {
             useEditorViewTypeStore.getState().setEditorViewType(curFile.id, payload)
             editorRef.current?.toggleType(payload)
           },
+          onFinally: () => {
+            editorTypeSwitchingRef.current = false
+          },
         })
       }
-    }
+    }, 300, { leading: true, trailing: false })
 
     bus.on('editor_toggle_type', cb)
 
     return () => {
+      cb.cancel()
       bus.detach('editor_toggle_type', cb)
     }
   }, [active, curFile, execute, setEditorDelegate, getEditorContent, debounceRefreshToc])
@@ -425,7 +469,10 @@ function TextEditor(props: TextEditorProps) {
 
   useEffect(() => {
     const callback = (hooks: SaveHandlerParams) => {
-      saveHandler({ onSuccess: hooks?.onSuccess })
+      if (!active) {
+        return
+      }
+      saveHandler({ onSuccess: hooks?.onSuccess, onFinally: hooks?.onFinally })
     }
 
     bus.on(EVENT.app_save, callback)
@@ -433,7 +480,7 @@ function TextEditor(props: TextEditorProps) {
     return () => {
       bus.detach(EVENT.app_save, callback)
     }
-  }, [saveHandler])
+  }, [active, saveHandler])
 
   const handleWrapperClick: React.MouseEventHandler<HTMLDivElement> = useCallback(
     (e) => {

--- a/apps/desktop/src/components/EditorArea/index.tsx
+++ b/apps/desktop/src/components/EditorArea/index.tsx
@@ -1,9 +1,14 @@
+import { EVENT } from '@/constants'
 import { FindReplace } from '@/components/EditorArea/editorToolBar/FindReplace'
 import { PreviewToolbar } from '@/components/EditorArea/editorToolBar/PreviewToolbar/PreviewToolbar'
 import { SourceCodeToolbar } from '@/components/EditorArea/editorToolBar/SourceCodeToolbar/SourceCodeToolbar'
 import { WysiwygToolbar } from '@/components/EditorArea/editorToolBar/WysiwygToolbar'
-import { useEditorStore } from '@/stores'
-import { memo } from 'react'
+import bus from '@/helper/eventBus'
+import { useCommandStore, useEditorStore } from '@/stores'
+import useEditorViewTypeStore from '@/stores/useEditorViewTypeStore'
+import useFileTypeConfigStore from '@/stores/useFileTypeConfigStore'
+import { memo, useEffect } from 'react'
+import { EditorViewType } from 'rme'
 import Editor from './Editor'
 import EditorAreaTabs from './EditorAreaTabs'
 import { EmptyState } from './EmptyState'
@@ -11,6 +16,34 @@ import { Container, EditorPanel } from './styles'
 
 function EditorArea() {
   const { opened, activeId } = useEditorStore()
+  const { addCommand } = useCommandStore()
+
+  useEffect(() => {
+    addCommand({
+      id: EVENT.app_toggleEditorType,
+      handler: () => {
+        const { activeId } = useEditorStore.getState()
+        if (!activeId) return
+
+        const fileTypeConfig = useFileTypeConfigStore.getState().getFileTypeConfigById(activeId)
+        if (!fileTypeConfig) return
+
+        const supportsToggle =
+          fileTypeConfig.supportedModes.includes(EditorViewType.SOURCECODE) &&
+          fileTypeConfig.supportedModes.includes(EditorViewType.WYSIWYG)
+
+        if (!supportsToggle) return
+
+        const currentViewType = useEditorViewTypeStore.getState().getEditorViewType(activeId)
+        const targetViewType =
+          currentViewType === EditorViewType.SOURCECODE
+            ? EditorViewType.WYSIWYG
+            : EditorViewType.SOURCECODE
+
+        bus.emit('editor_toggle_type', targetViewType)
+      },
+    })
+  }, [addCommand])
 
   if (opened.length === 0) {
     return <EmptyState />

--- a/apps/desktop/src/constants/event.ts
+++ b/apps/desktop/src/constants/event.ts
@@ -4,7 +4,8 @@ enum EVENT {
   app_openFolder = 'app_openFolder',
   app_openSetting = 'app_openSetting',
   app_hide = 'app_hide',
-  app_closeCurrentEditorTab = 'app_closeCurrentEditorTab'
+  app_closeCurrentEditorTab = 'app_closeCurrentEditorTab',
+  app_toggleEditorType = 'app_toggleEditorType',
 }
 
 export default EVENT

--- a/locales/en.json
+++ b/locales/en.json
@@ -174,6 +174,7 @@
       "app_findReplaceEditor": "Find and replace in editor",
       "app_closeCurrentEditorTab": "Close current editor tab",
       "app_hide": "Hide the application",
+      "app_toggleEditorType": "Toggle source code / WYSIWYG mode",
       "editor_copy": "Copy selected text in editor",
       "editor_cut": "Cut selected text in editor",
       "editor_redo": "Redo",

--- a/locales/es.json
+++ b/locales/es.json
@@ -461,6 +461,7 @@
       "app_findReplaceEditor": "Buscar y reemplazar en el editor",
       "app_closeCurrentEditorTab": "Cerrar la pestaña actual del editor",
       "app_hide": "Ocultar la aplicación",
+      "app_toggleEditorType": "Alternar entre modo código fuente y WYSIWYG",
       "editor_copy": "Copiar texto seleccionado en el editor",
       "editor_cut": "Cortar texto seleccionado en el editor",
       "editor_redo": "Rehacer",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -461,6 +461,7 @@
       "app_findReplaceEditor": "Rechercher et remplacer dans l'éditeur",
       "app_closeCurrentEditorTab": "Fermer l'onglet de l'éditeur actuel",
       "app_hide": "Cacher l'application",
+      "app_toggleEditorType": "Basculer entre les modes code source et WYSIWYG",
       "editor_copy": "Copier le texte sélectionné dans l'éditeur",
       "editor_cut": "Couper le texte sélectionné dans l'éditeur",
       "editor_redo": "Refaire",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -461,6 +461,7 @@
       "app_findReplaceEditor": "エディタで見つけて置き換える",
       "app_closeCurrentEditorTab": "現在のエディタタブを閉じる",
       "app_hide": "アプリケーションを隠す",
+      "app_toggleEditorType": "ソースコード/WYSIWYGモードを切り替える",
       "editor_copy": "選択したテキストをエディタでコピーする",
       "editor_cut": "エディタで選択したテキストをカット",
       "editor_redo": "再実行",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -472,6 +472,7 @@
       "app_findReplaceEditor": "在编辑器中查找和替换",
       "app_closeCurrentEditorTab": "关闭当前编辑器选项卡",
       "app_hide": "隐藏应用程序",
+      "app_toggleEditorType": "切换源代码/所见即所得模式",
       "editor_copy": "在编辑器中复制选定的文本",
       "editor_cut": "在编辑器中剪切所选文本",
       "editor_redo": "重做",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

- 新增 `app_toggleEditorType` 快捷键命令，用于在源代码和所见即所得模式之间切换。默认快捷键为 `CommandOrCtrl + Shift + M`。
- 为编辑器模式切换增加节流和切换中保护，避免快速重复触发带来的性能问题。
- 补充快捷键设置页中的多语言描述。

之前注册 `editor_toggle_editor` command 发现不起作用，可能是因为 `apps/desktop/src/hooks/useKeyboard.ts` 里有一条筛选，把 `editor_` 开头的都当成 rme 编辑器的内建快捷键，不会调用 useCommandStore，所以我改成了 `app_toggleEditorType`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

打开 Markdown 文件，快速按 Command + Shift + M 可正常在源代码和所见即所得模式之间切换，未观察到快速重复触发