### PR TITLE
feat: add file exclusion patterns setting and search/explorer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,39 +163,25 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/punkyard">
-            <img src="https://avatars.githubusercontent.com/u/59349105?v=4" width="90;" alt="punkyard"/>
+        <a href="https://github.com/SamDc73">
+            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
             <br />
-            <sub><b>Pun Kyard</b></sub>
+            <sub><b>Husam Alshehadat</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/hope-zjl">
-            <img src="https://avatars.githubusercontent.com/u/54581644?v=4" width="90;" alt="hope-zjl"/>
+        <a href="https://github.com/marianoesteban">
+            <img src="https://avatars.githubusercontent.com/u/3076449?v=4" width="90;" alt="marianoesteban"/>
             <br />
-            <sub><b>Null</b></sub>
+            <sub><b>Mariano Esteban</b></sub>
         </a>
     </td></tr>
 <tr>
     <td align="center">
-        <a href="https://github.com/fossabot">
-            <img src="https://avatars.githubusercontent.com/u/29791463?v=4" width="90;" alt="fossabot"/>
+        <a href="https://github.com/Raven-1027">
+            <img src="https://avatars.githubusercontent.com/u/83693755?v=4" width="90;" alt="Raven-1027"/>
             <br />
-            <sub><b>Fossabot</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/dai">
-            <img src="https://avatars.githubusercontent.com/u/12391?v=4" width="90;" alt="dai"/>
-            <br />
-            <sub><b>Dai</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/chiefass">
-            <img src="https://avatars.githubusercontent.com/u/106591791?v=4" width="90;" alt="chiefass"/>
-            <br />
-            <sub><b>Chiefass</b></sub>
+            <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
@@ -206,24 +192,38 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/Raven-1027">
-            <img src="https://avatars.githubusercontent.com/u/83693755?v=4" width="90;" alt="Raven-1027"/>
+        <a href="https://github.com/chiefass">
+            <img src="https://avatars.githubusercontent.com/u/106591791?v=4" width="90;" alt="chiefass"/>
+            <br />
+            <sub><b>Chiefass</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/dai">
+            <img src="https://avatars.githubusercontent.com/u/12391?v=4" width="90;" alt="dai"/>
+            <br />
+            <sub><b>Dai</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/fossabot">
+            <img src="https://avatars.githubusercontent.com/u/29791463?v=4" width="90;" alt="fossabot"/>
+            <br />
+            <sub><b>Fossabot</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/hope-zjl">
+            <img src="https://avatars.githubusercontent.com/u/54581644?v=4" width="90;" alt="hope-zjl"/>
             <br />
             <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/marianoesteban">
-            <img src="https://avatars.githubusercontent.com/u/3076449?v=4" width="90;" alt="marianoesteban"/>
+        <a href="https://github.com/punkyard">
+            <img src="https://avatars.githubusercontent.com/u/59349105?v=4" width="90;" alt="punkyard"/>
             <br />
-            <sub><b>Mariano Esteban</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/SamDc73">
-            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
-            <br />
-            <sub><b>Husam Alshehadat</b></sub>
+            <sub><b>Pun Kyard</b></sub>
         </a>
     </td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -149,13 +149,6 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/AdySnowflake">
-            <img src="https://avatars.githubusercontent.com/u/163967164?v=4" width="90;" alt="AdySnowflake"/>
-            <br />
-            <sub><b>Null</b></sub>
-        </a>
-    </td>
-    <td align="center">
         <a href="https://github.com/KiraKiraAyu">
             <img src="https://avatars.githubusercontent.com/u/99468824?v=4" width="90;" alt="KiraKiraAyu"/>
             <br />
@@ -163,39 +156,32 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/SamDc73">
-            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
-            <br />
-            <sub><b>Husam Alshehadat</b></sub>
-        </a>
-    </td>
-    <td align="center">
-        <a href="https://github.com/marianoesteban">
-            <img src="https://avatars.githubusercontent.com/u/3076449?v=4" width="90;" alt="marianoesteban"/>
-            <br />
-            <sub><b>Mariano Esteban</b></sub>
-        </a>
-    </td></tr>
-<tr>
-    <td align="center">
-        <a href="https://github.com/Raven-1027">
-            <img src="https://avatars.githubusercontent.com/u/83693755?v=4" width="90;" alt="Raven-1027"/>
+        <a href="https://github.com/AdySnowflake">
+            <img src="https://avatars.githubusercontent.com/u/163967164?v=4" width="90;" alt="AdySnowflake"/>
             <br />
             <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/andriishin">
-            <img src="https://avatars.githubusercontent.com/u/3613462?v=4" width="90;" alt="andriishin"/>
+        <a href="https://github.com/punkyard">
+            <img src="https://avatars.githubusercontent.com/u/59349105?v=4" width="90;" alt="punkyard"/>
             <br />
-            <sub><b>Alexander</b></sub>
+            <sub><b>Pun Kyard</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/chiefass">
-            <img src="https://avatars.githubusercontent.com/u/106591791?v=4" width="90;" alt="chiefass"/>
+        <a href="https://github.com/hope-zjl">
+            <img src="https://avatars.githubusercontent.com/u/54581644?v=4" width="90;" alt="hope-zjl"/>
             <br />
-            <sub><b>Chiefass</b></sub>
+            <sub><b>Null</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
+        <a href="https://github.com/fossabot">
+            <img src="https://avatars.githubusercontent.com/u/29791463?v=4" width="90;" alt="fossabot"/>
+            <br />
+            <sub><b>Fossabot</b></sub>
         </a>
     </td>
     <td align="center">
@@ -206,24 +192,38 @@ The development of **MarkFlowy** cannot be separated from these contributors. Th
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/fossabot">
-            <img src="https://avatars.githubusercontent.com/u/29791463?v=4" width="90;" alt="fossabot"/>
+        <a href="https://github.com/chiefass">
+            <img src="https://avatars.githubusercontent.com/u/106591791?v=4" width="90;" alt="chiefass"/>
             <br />
-            <sub><b>Fossabot</b></sub>
+            <sub><b>Chiefass</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/hope-zjl">
-            <img src="https://avatars.githubusercontent.com/u/54581644?v=4" width="90;" alt="hope-zjl"/>
+        <a href="https://github.com/andriishin">
+            <img src="https://avatars.githubusercontent.com/u/3613462?v=4" width="90;" alt="andriishin"/>
+            <br />
+            <sub><b>Alexander</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/Raven-1027">
+            <img src="https://avatars.githubusercontent.com/u/83693755?v=4" width="90;" alt="Raven-1027"/>
             <br />
             <sub><b>Null</b></sub>
         </a>
     </td>
     <td align="center">
-        <a href="https://github.com/punkyard">
-            <img src="https://avatars.githubusercontent.com/u/59349105?v=4" width="90;" alt="punkyard"/>
+        <a href="https://github.com/marianoesteban">
+            <img src="https://avatars.githubusercontent.com/u/3076449?v=4" width="90;" alt="marianoesteban"/>
             <br />
-            <sub><b>Pun Kyard</b></sub>
+            <sub><b>Mariano Esteban</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/SamDc73">
+            <img src="https://avatars.githubusercontent.com/u/144215270?v=4" width="90;" alt="SamDc73"/>
+            <br />
+            <sub><b>Husam Alshehadat</b></sub>
         </a>
     </td></tr>
 </table>

--- a/apps/desktop/src-tauri/src/app/conf.rs
+++ b/apps/desktop/src-tauri/src/app/conf.rs
@@ -64,6 +64,7 @@ pub_struct!(AppConf {
     wysiwyg_editor_spellcheck: Option<bool>,
     source_code_editor_spellcheck: Option<bool>,
     md_editor_default_mode: Option<String>,
+    file_exclude_patterns: Option<String>,
     when_paste_image: Option<String>,
     paste_image_save_absolute_path: Option<String>,
     paste_image_save_relative_path: Option<String>,
@@ -76,6 +77,8 @@ pub_struct!(AppConf {
 });
 
 pub const APP_CONF_PATH: &str = "markflowy.conf.json";
+pub const APP_FILE_EXCLUDE_PATTERNS_PATH: &str = "markflowy-ignore";
+pub const DEFAULT_EXCLUDE_PATTERNS: &str = ".DS_Store\n.git\nThumbs.db\n.svn\n.hg\n";
 pub const STORE_KEY: &str = "app_config_v3";
 
 fn create_store(app: &AppHandle) -> Result<std::sync::Arc<Store<tauri::Wry>>, String> {
@@ -121,6 +124,44 @@ pub fn app_root() -> PathBuf {
     }
 }
 
+pub fn file_exclude_patterns_path() -> PathBuf {
+    app_root().join(APP_FILE_EXCLUDE_PATTERNS_PATH)
+}
+
+fn read_or_create_file_exclude_patterns(fallback: Option<&str>) -> String {
+    let fallback = fallback.unwrap_or(DEFAULT_EXCLUDE_PATTERNS).to_string();
+    let path = file_exclude_patterns_path();
+
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        return content;
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            eprintln!("Failed to create directory {:?}: {}", parent, err);
+        }
+    }
+
+    if let Err(err) = std::fs::write(&path, &fallback) {
+        eprintln!("Failed to write file exclude patterns to {:?}: {}", path, err);
+    }
+    fallback
+}
+
+fn write_file_exclude_patterns(patterns: &str) {
+    let path = file_exclude_patterns_path();
+
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            eprintln!("Failed to create directory {:?}: {}", parent, err);
+        }
+    }
+
+    if let Err(err) = std::fs::write(&path, patterns) {
+        eprintln!("Failed to write file exclude patterns to {:?}: {}", path, err);
+    }
+}
+
 fn migrate_from_file(_app: &AppHandle) -> Option<AppConf> {
     let legacy_path = app_root().join(APP_CONF_PATH);
     if exists(&legacy_path) {
@@ -162,6 +203,7 @@ impl AppConf {
             wysiwyg_editor_spellcheck: Some(false),
             source_code_editor_spellcheck: Some(false),
             wysiwyg_editor_codemirror_line_wrap: Some(true),
+            file_exclude_patterns: Some(DEFAULT_EXCLUDE_PATTERNS.to_string()),
             extensions_chatgpt_apibase: Some("".to_string()),
             extensions_chatgpt_models: Some("gpt-3.5-turbo,gpt-4-32k,gpt-4".to_string()),
             extensions_chatgpt_apikey: Some("".to_string()),
@@ -197,6 +239,19 @@ impl AppConf {
 
     pub fn file_path() -> PathBuf {
         app_root().join(APP_CONF_PATH)
+    }
+
+    pub fn with_file_exclude_patterns_from_file(mut self) -> Self {
+        self.file_exclude_patterns = Some(read_or_create_file_exclude_patterns(
+            self.file_exclude_patterns.as_deref(),
+        ));
+        self
+    }
+
+    pub fn write_file_exclude_patterns(&self) {
+        if let Some(patterns) = self.file_exclude_patterns.as_deref() {
+            write_file_exclude_patterns(patterns);
+        }
     }
 
     pub fn read_from_store(app: &AppHandle) -> Result<Self, String> {
@@ -278,6 +333,7 @@ impl AppConf {
             wysiwyg_editor_codemirror_line_wrap,
             wysiwyg_editor_spellcheck,
             source_code_editor_spellcheck,
+            file_exclude_patterns,
             autosave_interval,
             extensions_chatgpt_apibase,
             extensions_chatgpt_apikey,
@@ -309,16 +365,18 @@ impl AppConf {
     }
 
     pub fn read_with_app(app: &AppHandle) -> Self {
-        match Self::read_from_store(app) {
-            Ok(conf) => Self::new().merge_conf(conf, app),
+        let conf = match Self::read_from_store(app) {
+            Ok(conf) => conf.with_file_exclude_patterns_from_file(),
             Err(err) => {
                 eprintln!("Failed to read from store: {}, falling back to file", err);
-                Self::default()
+                Self::default().with_file_exclude_patterns_from_file()
             }
-        }
+        };
+        Self::new().merge_conf(conf, app)
     }
 
     pub fn write_with_app(self, app: &AppHandle) -> Self {
+        self.write_file_exclude_patterns();
         match self.clone().write_to_store(app) {
             Ok(conf) => conf,
             Err(err) => {
@@ -340,10 +398,7 @@ impl AppConf {
             if exists(&legacy_path) {
                 let _ = std::fs::remove_file(&legacy_path);
             }
-            return self
-                .clone()
-                .write_to_store(app)
-                .unwrap_or_else(|_| Self::default());
+            return self.write_with_app(app);
         }
 
         Self::default()

--- a/apps/desktop/src-tauri/src/fc.rs
+++ b/apps/desktop/src-tauri/src/fc.rs
@@ -494,6 +494,40 @@ pub fn files_to_json(files: Vec<FileInfo>) -> FileResult {
     }
 }
 
+pub fn filter_files_by_exclude_patterns(
+    files: Vec<FileInfo>,
+    root_path: &str,
+    patterns: &str,
+) -> Vec<FileInfo> {
+    if patterns.trim().is_empty() {
+        return files;
+    }
+
+    let matcher = mf_file_search::exclude::build_exclude_matcher(root_path, patterns);
+    filter_files_with_exclude_matcher(files, &matcher)
+}
+
+fn filter_files_with_exclude_matcher(
+    files: Vec<FileInfo>,
+    matcher: &mf_file_search::exclude::ExcludeMatcher,
+) -> Vec<FileInfo> {
+    files
+        .into_iter()
+        .filter_map(|mut file| {
+            let is_dir = file.kind == "dir";
+            if mf_file_search::exclude::is_excluded_path(matcher, &file.path, is_dir) {
+                return None;
+            }
+
+            if let Some(children) = file.children.take() {
+                file.children = Some(filter_files_with_exclude_matcher(children, matcher));
+            }
+
+            Some(file)
+        })
+        .collect()
+}
+
 fn decode_utf16_bytes(bytes: &[u8], little_endian: bool) -> Result<String, String> {
     if bytes.len() % 2 != 0 {
         return Err(String::from("UTF-16 content has an odd byte length"));
@@ -1062,9 +1096,27 @@ pub mod cmd {
     use super::{FileResult, MoveFileInfo};
 
     #[tauri::command]
-    pub fn open_folder_async(folder_path: &str) -> FileResult {
+    pub fn open_folder_async(
+        folder_path: &str,
+        root_path: Option<String>,
+        file_exclude_patterns: Option<String>,
+    ) -> FileResult {
         match fc::read_directory(folder_path) {
-            Ok(files) => fc::files_to_json(files),
+            Ok(files) => {
+                let mut files = files;
+                if let Some(patterns) = file_exclude_patterns
+                    .as_deref()
+                    .filter(|patterns| !patterns.trim().is_empty())
+                {
+                    files = fc::filter_files_by_exclude_patterns(
+                        files,
+                        root_path.as_deref().unwrap_or(folder_path),
+                        patterns,
+                    );
+                }
+
+                fc::files_to_json(files)
+            }
             Err(code) => FileResult {
                 code,
                 content: String::from("Failed to read directory"),
@@ -1467,6 +1519,51 @@ pub mod cmd {
             }
         }
         #[cfg(not(target_os = "macos"))]
-        { true }
+        {
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_file(name: &str, kind: &str, path: &str) -> FileInfo {
+        FileInfo {
+            name: name.to_string(),
+            kind: kind.to_string(),
+            path: path.to_string(),
+            children: if kind == "dir" {
+                Some(Vec::new())
+            } else {
+                None
+            },
+            ext: Path::new(path)
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or("")
+                .to_string(),
+        }
+    }
+
+    #[test]
+    fn filters_directory_entries_with_rust_ignore_matcher() {
+        let files = vec![
+            test_file("build", "dir", "/workspace/build"),
+            test_file("src", "dir", "/workspace/src"),
+            test_file("keep.tmp", "file", "/workspace/keep.tmp"),
+            test_file("drop.tmp", "file", "/workspace/drop.tmp"),
+        ];
+
+        let filtered =
+            filter_files_by_exclude_patterns(files, "/workspace", "/build/\n*.tmp\n!keep.tmp\n");
+
+        let names = filtered
+            .iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["src", "keep.tmp"]);
     }
 }

--- a/apps/desktop/src-tauri/src/search.rs
+++ b/apps/desktop/src-tauri/src/search.rs
@@ -2,13 +2,17 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct SearchOptions {
+    #[serde(default)]
     content_case_sensitive: bool,
+    #[serde(default)]
+    file_exclude_patterns: Option<String>,
 }
 
 impl Default for SearchOptions {
     fn default() -> Self {
         Self {
             content_case_sensitive: false,
+            file_exclude_patterns: None,
         }
     }
 }
@@ -78,11 +82,20 @@ pub mod cmd {
                 let search_result = tokio::task::spawn_blocking(move || {
                     let (s, r) = channel();
                     let default_options = Options::default();
+                    let mut name_options = default_options.name;
+                    let mut content_options = ContentOptions {
+                        case_sensitive: options.content_case_sensitive,
+                        ..Default::default()
+                    };
+
+                    if let Some(exclude_patterns) = options.file_exclude_patterns {
+                        name_options.exclude_patterns = exclude_patterns.clone();
+                        content_options.exclude_patterns = exclude_patterns;
+                    }
+
                     let opts = Options {
-                        name: default_options.name,
-                        content: ContentOptions {
-                            case_sensitive: options.content_case_sensitive,
-                        },
+                        name: name_options,
+                        content: content_options,
                         sort: default_options.sort,
                         last_dir: default_options.last_dir,
                         name_history: default_options.name_history,

--- a/apps/desktop/src/adapters/FileSystemAdapter.tsx
+++ b/apps/desktop/src/adapters/FileSystemAdapter.tsx
@@ -7,32 +7,49 @@ import {
   FileSystemContextValue,
   MoveFileInfo,
 } from '@markflowy/interface'
+import { logger } from '@/helper/logger'
+import { resolveFileExcludePatterns } from '@/helper/file-exclude'
 import { FileResultCode, FileSysResult, IFile } from '@/helper/filesys'
 import {
   getFileObjectByPath,
   setFileObjects,
   setFileObjectsByPath,
 } from '@/helper/files'
+import { useEditorStore } from '@/stores'
+import useAppSettingStore from '@/stores/useAppSettingStore'
 
 interface FileSystemAdapterProps {
   children: ReactNode
 }
 
 export const TauriFileSystemProvider: FC<FileSystemAdapterProps> = ({ children }) => {
+  const settingData = useAppSettingStore((state) => state.settingData)
+  const fileExcludePatterns = resolveFileExcludePatterns(settingData)
+
   const value: FileSystemContextValue = {
     readDirectory: async (folderPath: string): Promise<IFile[]> => {
-      const result = await invoke<FileSysResult>('open_folder_async', { folderPath })
+      const result = await invoke<FileSysResult>('open_folder_async', {
+        folderPath,
+        rootPath: folderPath,
+        fileExcludePatterns,
+      })
       if (result.code !== FileResultCode.Success) {
         throw new Error(`Failed to read directory: ${result.code}`)
       }
-      const files = JSON.parse(result.content)
+      const files = JSON.parse(result.content) as IFile[]
       // Note: wrapFiles logic should be handled by the caller
       return files
     },
 
     readSubdirectory: async (folderPath: string): Promise<IFile[]> => {
-      const result = await invoke<FileSysResult>('open_folder_async', { folderPath })
+      const rootPath = useEditorStore.getState().getRootPath() || folderPath
+      const result = await invoke<FileSysResult>('open_folder_async', {
+        folderPath,
+        rootPath,
+        fileExcludePatterns,
+      })
       if (result.code !== FileResultCode.Success) {
+        logger.error(`Failed to read subdirectory at ${folderPath}: ${result.code}`)
         return []
       }
       const files = JSON.parse(result.content) as IFile[]

--- a/apps/desktop/src/extensions/search/index.tsx
+++ b/apps/desktop/src/extensions/search/index.tsx
@@ -1,9 +1,11 @@
 import type { RightBarItem } from '@/components/SideBar'
 import { MfIconButton } from '@/components/ui-v2/Button'
 import { RIGHTBARITEMKEYS } from '@/constants'
+import { resolveFileExcludePatterns } from '@/helper/file-exclude'
 import { getFileObjectByPath } from '@/helper/files'
 import { logger } from '@/helper/logger'
 import { useEditorStore } from '@/stores'
+import useAppSettingStore from '@/stores/useAppSettingStore'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { invoke } from '@tauri-apps/api/core'
 import classNames from 'classnames'
@@ -93,6 +95,7 @@ const SearchView = memo(() => {
   const { resultList, addSearchResult, searchKeyword, caseSensitive, activeIndex, setSearchState } =
     useSearchStore()
   const { addOpenedFile, setActiveId, folderData, editorCtxMap, activeId } = useEditorStore()
+  const settingData = useAppSettingStore((state) => state.settingData)
   const [expandIdMap, setExpandIdMap] = useState<Record<string, boolean>>({})
   const [isSearching, setIsSearching] = useState(false)
   const [hasSearched, setHasSearched] = useState(false)
@@ -166,6 +169,10 @@ const SearchView = memo(() => {
 
   const isAllExpand = resultList.length > 0 && resultList.every((item) => expandIdMap[item.id])
   const trimmedKeyword = searchKeyword.trim()
+  const fileExcludePatterns = useMemo(
+    () => resolveFileExcludePatterns(settingData),
+    [settingData],
+  )
   const resultFileCount = resultList.length
   const resultMatchCount = useMemo(
     () =>
@@ -245,6 +252,7 @@ const SearchView = memo(() => {
         },
         options: {
           content_case_sensitive: caseSensitive,
+          file_exclude_patterns: fileExcludePatterns,
         },
       })
 
@@ -271,7 +279,7 @@ const SearchView = memo(() => {
         setIsSearching(false)
       }
     }
-  }, [folderData, searchKeyword, caseSensitive, setSearchState, addSearchResult])
+  }, [folderData, searchKeyword, caseSensitive, fileExcludePatterns, setSearchState, addSearchResult])
 
   const toggleCaseSensitive = useCallback(() => {
     searchRequestIdRef.current += 1

--- a/apps/desktop/src/helper/file-exclude.ts
+++ b/apps/desktop/src/helper/file-exclude.ts
@@ -1,0 +1,24 @@
+export const FILE_EXCLUDE_PATTERNS_SETTING_KEY = 'file_exclude_patterns'
+
+export function resolveFileExcludePatterns(settingData?: Record<string, unknown>) {
+  const value = settingData?.[FILE_EXCLUDE_PATTERNS_SETTING_KEY]
+  return typeof value === 'string' ? value : ''
+}
+
+export function parseFileExcludePatternLines(patterns: string) {
+  return patterns
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export function stringifyFileExcludePatternLines(patterns: string[]) {
+  return parseFileExcludePatternLines(patterns.join('\n')).join('\n')
+}
+
+export function hasFileExcludePatternsChanged(
+  prevSettingData?: Record<string, unknown>,
+  nextSettingData?: Record<string, unknown>,
+) {
+  return resolveFileExcludePatterns(prevSettingData) !== resolveFileExcludePatterns(nextSettingData)
+}

--- a/apps/desktop/src/helper/filesys.ts
+++ b/apps/desktop/src/helper/filesys.ts
@@ -1,9 +1,10 @@
 import { useEditorStore } from '@/stores'
-import type { FileEntry, IFile } from '@markflowy/interface'
+import useAppSettingStore from '@/stores/useAppSettingStore'
+import type { FileEntry, FileSysResult, IFile } from '@markflowy/interface'
 import { FileResultCode } from '@markflowy/interface'
 import { invoke } from '@tauri-apps/api/core'
-import { readDir } from '@tauri-apps/plugin-fs'
 import { nanoid } from 'nanoid'
+import { resolveFileExcludePatterns } from './file-exclude'
 import {
   getFileObjectByPath,
   setFileObject,
@@ -75,32 +76,26 @@ export const createUntitledFile = (): IFile => {
   return createFile()
 }
 
-export const readDirectory = async (folderPath: string): Promise<IFile[]> => {
-  const entries: IFile[] = []
-  
-  try {
-    const dirEntries = await readDir(folderPath)
-    
-    for (const entry of dirEntries) {
-      const fileName = entry.name
-      const filePath = `${folderPath}/${fileName}`
-      const ext = fileName.includes('.') ? fileName.split('.').pop() || '' : ''
-      
-      const isDir = entry.isDirectory
-      
-      const fileEntry: IFile = {
-        id: nanoid(),
-        name: fileName,
-        kind: isDir ? 'dir' : 'file',
-        path: filePath,
-        children: isDir ? [] : undefined,
-        ext: isDir ? '' : ext,
-      }
+const readDirectoryEntries = async (
+  folderPath: string,
+  rootPath = folderPath,
+): Promise<IFile[]> => {
+  const result = await invoke<FileSysResult>('open_folder_async', {
+    folderPath,
+    rootPath,
+    fileExcludePatterns: getCurrentFileExcludePatterns(),
+  })
 
-      entries.push(fileEntry)
-    }
-    
-    sortFilesByKindAndName(entries)
+  if (result.code !== FileResultCode.Success) {
+    throw new Error(`Failed to read directory: ${result.code}`)
+  }
+
+  return JSON.parse(result.content) as IFile[]
+}
+
+export const readDirectory = async (folderPath: string): Promise<IFile[]> => {
+  try {
+    const entries = await readDirectoryEntries(folderPath)
     wrapFiles(entries)
     
     const folderName = await invoke<string>('get_path_name', {
@@ -124,46 +119,23 @@ export const readDirectory = async (folderPath: string): Promise<IFile[]> => {
   }
 }
 
-const sortFilesByKindAndName = (files: IFile[]) => {
-  files.sort((a, b) => {
-    if (a.kind === 'dir' && b.kind !== 'dir') return -1
-    if (a.kind !== 'dir' && b.kind === 'dir') return 1
-    return a.name.localeCompare(b.name, undefined, { numeric: true })
-  })
-}
-
 export const readSubdirectory = async (folderPath: string): Promise<IFile[]> => {
-  const entries: IFile[] = []
-  
   try {
-    const dirEntries = await readDir(folderPath)
-    
-    for (const entry of dirEntries) {
-      const fileName = entry.name
-      const filePath = `${folderPath}/${fileName}`
-      const ext = fileName.includes('.') ? fileName.split('.').pop() || '' : ''
-      
-      const isDir = entry.isDirectory
-      
-      const fileEntry: IFile = {
-        id: nanoid(),
-        name: fileName,
-        kind: isDir ? 'dir' : 'file',
-        path: filePath,
-        children: isDir ? [] : undefined,
-        ext: isDir ? '' : ext,
-      }
-      
-      entries.push(fileEntry)
-    }
-    
-    sortFilesByKindAndName(entries)
+    const entries = await readDirectoryEntries(folderPath, getFileExcludeRootPath(folderPath))
     wrapFiles(entries)
     
     return entries
   } catch (err) {
     return []
   }
+}
+
+const getCurrentFileExcludePatterns = () => {
+  return resolveFileExcludePatterns(useAppSettingStore.getState().settingData)
+}
+
+const getFileExcludeRootPath = (folderPath: string) => {
+  return useEditorStore.getState().getRootPath() || folderPath
 }
 
 export function isMdFile(fileName?: string) {

--- a/apps/desktop/src/helper/test/file-exclude.test.ts
+++ b/apps/desktop/src/helper/test/file-exclude.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  hasFileExcludePatternsChanged,
+  parseFileExcludePatternLines,
+  resolveFileExcludePatterns,
+  stringifyFileExcludePatternLines,
+} from '../file-exclude'
+
+describe('file exclusion patterns', () => {
+  it('does not own the default exclusion list on the frontend', () => {
+    expect(resolveFileExcludePatterns({})).toBe('')
+  })
+
+  it('normalizes pattern text for list editing', () => {
+    expect(parseFileExcludePatternLines('\n .git \n\n.svn\r\n')).toEqual([
+      '.git',
+      '.svn',
+    ])
+
+    expect(stringifyFileExcludePatternLines([' .git ', '', '.svn'])).toBe(
+      '.git\n.svn',
+    )
+  })
+
+  it('detects file exclusion setting changes only', () => {
+    expect(hasFileExcludePatternsChanged(
+      { file_exclude_patterns: '.git' },
+      { file_exclude_patterns: '.git\n.svn' },
+    )).toBe(true)
+
+    expect(hasFileExcludePatternsChanged(
+      { file_exclude_patterns: '.git', theme: 'light' },
+      { file_exclude_patterns: '.git', theme: 'dark' },
+    )).toBe(false)
+  })
+})

--- a/apps/desktop/src/helper/test/filesys.test.ts
+++ b/apps/desktop/src/helper/test/filesys.test.ts
@@ -10,10 +10,6 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }))
 
-vi.mock('@tauri-apps/plugin-fs', () => ({
-  readDir: vi.fn(),
-}))
-
 vi.mock('rme', () => ({}))
 
 vi.mock('antd', () => ({}))

--- a/apps/desktop/src/hooks/useAppSetup.ts
+++ b/apps/desktop/src/hooks/useAppSetup.ts
@@ -2,6 +2,7 @@ import { commandRegistry } from '@/commands'
 import useAiChatStore from '@/extensions/ai/useAiChatStore'
 import bus from '@/helper/eventBus'
 import { loadLocalThemeCss } from '@/helper/extensions'
+import { hasFileExcludePatternsChanged } from '@/helper/file-exclude'
 import { getFileObject, getFileObjectByPath, getSaveOpenedEditorEntries } from '@/helper/files'
 import { createFile, getFileNameFromPath, readDirectory, releaseSecurityScope } from '@/helper/filesys'
 import { logger } from '@/helper/logger'
@@ -28,6 +29,7 @@ import { isArray } from '../helper'
 import useExtensionsManagerStore from '../stores/useExtensionsManagerStore'
 import useThemeStore from '../stores/useThemeStore'
 import useWorkspaceWatcher from './useWorkspaceWatcher'
+import { fileTreeHandler } from '@markflowy/interface'
 
 interface LocalTheme {
   id: string
@@ -264,6 +266,23 @@ async function appWorkspaceSetup() {
   }
 }
 
+async function refreshWorkspaceFileTree() {
+  const { getRootPath, setFolderDataPure } = useEditorStore.getState()
+  const rootPath = getRootPath()
+
+  if (!rootPath) {
+    return
+  }
+
+  try {
+    fileTreeHandler.clearLoadedDirsCache?.()
+    const folderData = await readDirectory(rootPath)
+    setFolderDataPure(folderData)
+  } catch (error) {
+    logger.error('Failed to refresh workspace after file exclude setting change', error)
+  }
+}
+
 const listener = (event: MessageEvent) => {
   if (event.origin !== window.location.origin) {
     return
@@ -353,7 +372,12 @@ const useAppSetup = () => {
     })
 
     const settingDataUpdate = currentWindow.listen('app_conf_change', async () => {
-      appSettingStoreSetup()
+      const prevSettingData = useAppSettingStore.getState().settingData
+      const nextSettingData = await appSettingStoreSetup()
+
+      if (hasFileExcludePatternsChanged(prevSettingData, nextSettingData)) {
+        await refreshWorkspaceFileTree()
+      }
     })
 
     const unListenMenu = currentWindow.listen<string>('native:menu', ({ payload }) => {

--- a/apps/desktop/src/router/Setting/component/SettingItems/FileExcludePatterns.tsx
+++ b/apps/desktop/src/router/Setting/component/SettingItems/FileExcludePatterns.tsx
@@ -1,0 +1,361 @@
+import appSettingService from '@/services/app-setting'
+import useAppSettingStore from '@/stores/useAppSettingStore'
+import {
+  parseFileExcludePatternLines,
+  stringifyFileExcludePatternLines,
+} from '@/helper/file-exclude'
+import { Input } from 'antd'
+import { nanoid } from 'nanoid'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from '@/i18n'
+import styled from 'styled-components'
+import type { SettingItemProps } from '.'
+import { SettingItemContainer } from './Container'
+import { SettingLabel } from './Label'
+
+interface ExcludeItem {
+  id: string
+  value: string
+}
+
+interface FileExcludeRowItemProps {
+  value: string
+  placeholder?: string
+  onSave: (newValue: string) => void
+  onDelete: () => void
+}
+
+const FileExcludeRowItem = memo<FileExcludeRowItemProps>(
+  ({ value, placeholder, onSave, onDelete }) => {
+    const [isEditing, setIsEditing] = useState(false)
+    const [editingValue, setEditingValue] = useState(value)
+    const isCancelledRef = useRef(false)
+
+    const handleCommit = useCallback(() => {
+      if (isCancelledRef.current) {
+        isCancelledRef.current = false
+        return
+      }
+      const val = editingValue.trim()
+      onSave(val)
+      setIsEditing(false)
+    }, [editingValue, onSave])
+
+    const handleCancel = useCallback(() => {
+      isCancelledRef.current = true
+      setIsEditing(false)
+      setEditingValue(value)
+    }, [value])
+
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+          event.currentTarget.blur()
+        } else if (event.key === 'Escape') {
+          handleCancel()
+        }
+      },
+      [handleCancel],
+    )
+
+    return (
+      <RowWrapper>
+        {isEditing ? (
+          <Input
+            autoFocus
+            size='small'
+            value={editingValue}
+            placeholder={placeholder || 'Enter value...'}
+            onChange={(e) => setEditingValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleCommit}
+            style={{ fontFamily: 'monospace' }}
+          />
+        ) : (
+          <>
+            <RowText>{value}</RowText>
+            <RowActions className='row-actions'>
+              <IconButton
+                aria-label='Edit item'
+                onClick={() => {
+                  setEditingValue(value)
+                  setIsEditing(true)
+                }}
+              >
+                <i className='ri-pencil-line' />
+              </IconButton>
+              <IconButton aria-label='Delete item' onClick={onDelete}>
+                <i className='ri-close-line' />
+              </IconButton>
+            </RowActions>
+          </>
+        )}
+      </RowWrapper>
+    )
+  },
+)
+
+interface AddingExcludeRowItemProps {
+  placeholder?: string
+  onSave: (value: string) => void
+  onCancel: () => void
+}
+
+const AddingExcludeRowItem = memo<AddingExcludeRowItemProps>(
+  ({ placeholder, onSave, onCancel }) => {
+    const [addValue, setAddValue] = useState('')
+    const isCancelledRef = useRef(false)
+
+    const handleCommit = useCallback(() => {
+      if (isCancelledRef.current) {
+        isCancelledRef.current = false
+        return
+      }
+      const val = addValue.trim()
+      onSave(val)
+    }, [addValue, onSave])
+
+    const handleCancel = useCallback(() => {
+      isCancelledRef.current = true
+      onCancel()
+    }, [onCancel])
+
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+          event.currentTarget.blur()
+        } else if (event.key === 'Escape') {
+          handleCancel()
+        }
+      },
+      [handleCancel],
+    )
+
+    return (
+      <RowWrapper>
+        <Input
+          autoFocus
+          size='small'
+          value={addValue}
+          placeholder={placeholder || 'Enter value...'}
+          onChange={(e) => setAddValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleCommit}
+          style={{ fontFamily: 'monospace' }}
+        />
+      </RowWrapper>
+    )
+  },
+)
+
+const FileExcludePatternsSettingItem: React.FC<
+  SettingItemProps<Setting.FileExcludePatternsSettingItem>
+> = memo((props) => {
+  const { item } = props
+  const { settingData } = useAppSettingStore()
+  const { t } = useTranslation()
+  const curValue = (settingData[item.key] as unknown as string) || ''
+
+  const parsedLines = useMemo(() => parseFileExcludePatternLines(curValue), [curValue])
+  const [items, setItems] = useState<ExcludeItem[]>(() =>
+    parsedLines.map((value) => ({ id: nanoid(), value })),
+  )
+  const [adding, setAdding] = useState(false)
+
+  useEffect(() => {
+    setItems((prevItems) => {
+      const prevValues = prevItems.map((i) => i.value)
+      if (
+        prevValues.length === parsedLines.length &&
+        prevValues.every((val, index) => val === parsedLines[index])
+      ) {
+        return prevItems
+      }
+      return parsedLines.map((value) => {
+        const matched = prevItems.find((i) => i.value === value)
+        return { id: matched ? matched.id : nanoid(), value }
+      })
+    })
+  }, [parsedLines])
+
+  const writeItems = useCallback(
+    (nextItems: ExcludeItem[]) => {
+      setItems(nextItems)
+      const value = stringifyFileExcludePatternLines(nextItems.map((i) => i.value))
+      appSettingService.writeSettingData(item, value)
+    },
+    [item],
+  )
+
+  const handleItemSave = useCallback(
+    (id: string, newValue: string) => {
+      const nextItems = newValue
+        ? items.map((i) => (i.id === id ? { ...i, value: newValue } : i))
+        : items.filter((i) => i.id !== id)
+      writeItems(nextItems)
+    },
+    [items, writeItems],
+  )
+
+  const handleItemDelete = useCallback(
+    (id: string) => {
+      writeItems(items.filter((i) => i.id !== id))
+    },
+    [items, writeItems],
+  )
+
+  const handleAddSave = useCallback(
+    (newValue: string) => {
+      if (newValue) {
+        writeItems([...items, { id: nanoid(), value: newValue }])
+      }
+      setAdding(false)
+    },
+    [items, writeItems],
+  )
+
+  return (
+    <SettingItemContainer $direction='column'>
+      <SettingLabel item={item} style={{ marginBottom: '8px' }} />
+      <ContainerWrapper>
+        <ListWrapper>
+          {items.length === 0 && !adding && <EmptyHint>{t('common.none')}</EmptyHint>}
+
+          {items.map((listItem) => (
+            <FileExcludeRowItem
+              key={listItem.id}
+              value={listItem.value}
+              placeholder={item.placeholder}
+              onSave={(newValue) => handleItemSave(listItem.id, newValue)}
+              onDelete={() => handleItemDelete(listItem.id)}
+            />
+          ))}
+
+          {adding && (
+            <AddingExcludeRowItem
+              placeholder={item.placeholder}
+              onSave={handleAddSave}
+              onCancel={() => setAdding(false)}
+            />
+          )}
+        </ListWrapper>
+
+        {!adding && (
+          <AddButton onClick={() => setAdding(true)}>
+            <i className='ri-add-line' />
+            {t(item.i18nProps?.add || 'common.addPattern')}
+          </AddButton>
+        )}
+      </ContainerWrapper>
+    </SettingItemContainer>
+  )
+})
+
+const ContainerWrapper = styled.div`
+  width: 100%;
+  max-width: 500px;
+`
+
+const ListWrapper = styled.div`
+  width: 100%;
+  min-height: 48px;
+  margin-bottom: 8px;
+  border: 1px solid ${({ theme }) => theme.borderColor};
+  border-radius: 6px;
+  background: ${({ theme }) => theme.bgColorSecondary};
+`
+
+const RowActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+`
+
+const RowWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 8px;
+  color: ${({ theme }) => theme.primaryFontColor};
+
+  &:hover,
+  &:focus-within {
+    background: ${({ theme }) => theme.hoverColor};
+  }
+
+  &:hover .row-actions,
+  &:focus-within .row-actions {
+    opacity: 1;
+  }
+`
+
+const RowText = styled.div`
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const EmptyHint = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  color: ${({ theme }) => theme.labelFontColor};
+  font-size: 13px;
+`
+
+const IconButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: ${({ theme }) => theme.labelFontColor};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.bgColor};
+    color: ${({ theme }) => theme.accentColor};
+  }
+
+  i {
+    font-size: 14px;
+  }
+`
+
+const AddButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px dashed ${({ theme }) => theme.borderColor};
+  border-radius: 4px;
+  background-color: transparent;
+  color: ${({ theme }) => theme.primaryFontColor};
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 13px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.hoverColor};
+    border-color: ${({ theme }) => theme.accentColor};
+    color: ${({ theme }) => theme.accentColor};
+  }
+
+  i {
+    font-size: 14px;
+  }
+`
+
+export default FileExcludePatternsSettingItem

--- a/apps/desktop/src/router/Setting/component/SettingItems/index.tsx
+++ b/apps/desktop/src/router/Setting/component/SettingItems/index.tsx
@@ -4,6 +4,7 @@ import SelectSettingItem from './Select'
 import SliderSettingItem from './Slider'
 import StringMapJsonSettingItem from './StringMapJson'
 import SwitchSettingItem from './Switch'
+import FileExcludePatternsSettingItem from './FileExcludePatterns'
 import {
   isFontListSelectSettingItem,
   isInputSettingItem,
@@ -11,6 +12,7 @@ import {
   isSliderSettingItem,
   isStringMapJsonSettingItem,
   isSwitchSettingItem,
+  isFileExcludePatternsSettingItem,
 } from './types'
 
 const SettingItem: React.FC<SettingItemProps> = (props) => {
@@ -20,6 +22,9 @@ const SettingItem: React.FC<SettingItemProps> = (props) => {
 
   if (isInputSettingItem(item))
     return <InputSettingItem key={item.key} item={item} {...otherProps} />
+
+  if (isFileExcludePatternsSettingItem(item))
+    return <FileExcludePatternsSettingItem key={item.key} item={item} {...otherProps} />
 
   if (isSwitchSettingItem(item))
     return <SwitchSettingItem key={item.key} item={item} {...otherProps} />

--- a/apps/desktop/src/router/Setting/component/SettingItems/types.ts
+++ b/apps/desktop/src/router/Setting/component/SettingItems/types.ts
@@ -6,6 +6,10 @@ export function isInputSettingItem(item: Setting.SettingItem): item is Setting.I
   return item.type === 'input'
 }
 
+export function isFileExcludePatternsSettingItem(item: Setting.SettingItem): item is Setting.FileExcludePatternsSettingItem {
+  return item?.type === 'listInput' || item?.type === 'list-input' || item?.type === 'file-exclude-patterns'
+}
+
 export function isSwitchSettingItem(item: Setting.SettingItem): item is Setting.SwitchSettingItem {
   return item.type === 'switch'
 }

--- a/apps/desktop/src/router/Setting/settingMap.ts
+++ b/apps/desktop/src/router/Setting/settingMap.ts
@@ -66,6 +66,20 @@ export const getSettingMap = () => {
             changeLng(val)
           },
         },
+        fileExcludePatterns: {
+          key: 'file_exclude_patterns',
+          type: 'listInput',
+          placeholder: 'e.g. **/node_modules/*',
+          title: {
+            i18nKey: 'settings.general.misc.file_exclude_patterns.label',
+          },
+          desc: {
+            i18nKey: 'settings.general.misc.file_exclude_patterns.desc',
+          },
+          i18nProps: {
+            add: 'common.addPattern',
+          },
+        },
       },
     },
     display: {

--- a/apps/desktop/src/types/setting.d.ts
+++ b/apps/desktop/src/types/setting.d.ts
@@ -12,6 +12,7 @@ declare namespace Setting {
   type SettingItem =
     | SelectSettingItem
     | InputSettingItem
+    | FileExcludePatternsSettingItem
     | SwitchSettingItem
     | SliderSettingItem
     | FontListSelectSettingItem
@@ -49,6 +50,14 @@ declare namespace Setting {
     prefix?: string
     suffix?: string
     valuePreHandle?: (val: string) => string
+  } & BaseSettingItem
+
+  type FileExcludePatternsSettingItem = {
+    type: 'listInput' | 'list-input' | 'file-exclude-patterns'
+    placeholder?: string
+    i18nProps?: {
+      add?: string
+    }
   } & BaseSettingItem
 
   type SwitchSettingItem = {

--- a/crates/file_search/src/exclude.rs
+++ b/crates/file_search/src/exclude.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+pub type ExcludeMatcher = Gitignore;
+
+pub fn build_exclude_matcher<P: AsRef<Path>>(root: P, patterns: &str) -> Gitignore {
+    let mut builder = GitignoreBuilder::new(&root);
+
+    for line in patterns.lines() {
+        let _ = builder.add_line(None, line);
+    }
+
+    builder.build().unwrap_or_else(|err| {
+        eprintln!(
+            "Failed to build gitignore exclude matcher for {:?}: {}",
+            root.as_ref(),
+            err
+        );
+        Gitignore::empty()
+    })
+}
+
+pub fn is_excluded_path<P: AsRef<Path>>(matcher: &Gitignore, path: P, is_dir: bool) -> bool {
+    matcher.matched(path, is_dir).is_ignore()
+}

--- a/crates/file_search/src/lib.rs
+++ b/crates/file_search/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod exclude;
 pub mod fileinfo;
 pub mod manager;
 pub mod options;

--- a/crates/file_search/src/manager.rs
+++ b/crates/file_search/src/manager.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use clipboard::{ClipboardContext, ClipboardProvider};
 use ignore::WalkBuilder;
 
+use crate::exclude::{build_exclude_matcher, is_excluded_path};
 use crate::fileinfo::{FileInfo, Match};
 use crate::options::{FTypes, Options, Sort};
 use crate::rgtools::{self, SEPARATOR};
@@ -160,13 +161,23 @@ impl Manager {
         let re = re.unwrap();
         let re = Arc::new(re);
 
-        let walker = WalkBuilder::new(dir)
+        let exclude_matcher = build_exclude_matcher(dir, &options.name.exclude_patterns);
+        let mut walker_builder = WalkBuilder::new(dir);
+        walker_builder
             .follow_links(options.name.follow_links)
             .same_file_system(options.name.same_filesystem)
             .threads(num_cpus::get())
             .hidden(options.name.ignore_dot)
-            .git_ignore(options.name.use_gitignore)
-            .build_parallel();
+            .git_ignore(options.name.use_gitignore);
+
+        if !exclude_matcher.is_empty() {
+            walker_builder.filter_entry(move |entry| {
+                let is_dir = entry.file_type().map(|file_type| file_type.is_dir()).unwrap_or(false);
+                !is_excluded_path(&exclude_matcher, entry.path(), is_dir)
+            });
+        }
+
+        let walker = walker_builder.build_parallel();
 
         //walk dir
         walker.run(|| {
@@ -442,5 +453,55 @@ mod tests {
                 SearchResult::SearchErrors(_) => panic!(),
             }
         }
+    }
+
+    #[test]
+    fn find_names_respects_exclude_patterns() {
+        let mut dir = std::env::temp_dir();
+        dir.push("markflowy_exclude_patterns_test");
+        if dir.exists() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        std::fs::create_dir_all(dir.join("ignored")).unwrap();
+        std::fs::write(dir.join("visible.md"), "visible").unwrap();
+        std::fs::write(dir.join("Thumbs.db"), "thumb").unwrap();
+        std::fs::write(dir.join("draft.tmp"), "draft").unwrap();
+        std::fs::write(dir.join("keep.tmp"), "keep").unwrap();
+        std::fs::write(dir.join("ignored").join("nested.md"), "nested").unwrap();
+
+        let (s, r) = channel();
+        let mut options = Options::default();
+        options.name.ignore_dot = false;
+        options.name.use_gitignore = false;
+        options.name.exclude_patterns = "Thumbs.db\n*.tmp\n!keep.tmp\nignored/".to_string();
+
+        Manager::find_names(
+            &Search {
+                dir: dir.to_string_lossy().to_string(),
+                name_text: ".*".to_string(),
+                contents_text: "".to_string(),
+            },
+            options,
+            1,
+            s,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        let names: Vec<String> = r
+            .try_iter()
+            .filter_map(|message| match message {
+                Message::File(file, _) => Some(file.name),
+                _ => None,
+            })
+            .collect();
+
+        assert!(names.contains(&"visible.md".to_string()));
+        assert!(names.contains(&"keep.tmp".to_string()));
+        assert!(!names.contains(&"Thumbs.db".to_string()));
+        assert!(!names.contains(&"draft.tmp".to_string()));
+        assert!(!names.contains(&"ignored".to_string()));
+        assert!(!names.contains(&"nested.md".to_string()));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/file_search/src/options.rs
+++ b/crates/file_search/src/options.rs
@@ -44,6 +44,8 @@ pub struct NameOptions {
     pub ignore_dot: bool,
     #[serde(default = "bool_true")]
     pub use_gitignore: bool,
+    #[serde(default)]
+    pub exclude_patterns: String,
 }
 
 fn bool_true() -> bool {
@@ -59,13 +61,26 @@ impl Default for NameOptions {
             follow_links: false,
             ignore_dot: true,
             use_gitignore: true,
+            exclude_patterns: String::new(),
         }
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ContentOptions {
+    #[serde(default)]
     pub case_sensitive: bool,
+    #[serde(default)]
+    pub exclude_patterns: String,
+}
+
+impl Default for ContentOptions {
+    fn default() -> Self {
+        Self {
+            case_sensitive: false,
+            exclude_patterns: String::new(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Default)]

--- a/crates/file_search/src/rgtools.rs
+++ b/crates/file_search/src/rgtools.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use walkdir::WalkDir;
 
+use crate::exclude::{build_exclude_matcher, is_excluded_path};
 use crate::options::ContentOptions;
 
 struct MyWrite {
@@ -54,7 +55,19 @@ pub fn search_contents(
         .build_no_color(my_write);
 
     if let Some(allowed_files) = allowed_files {
+        let exclude_matchers = paths
+            .iter()
+            .map(|path| build_exclude_matcher(path, &ops.exclude_patterns))
+            .collect::<Vec<_>>();
+
         for path in allowed_files {
+            if exclude_matchers
+                .iter()
+                .any(|matcher| is_excluded_path(matcher, &path, false))
+            {
+                continue;
+            }
+
             let file = File::open(&path);
             if file.is_err() {
                 continue;
@@ -67,7 +80,11 @@ pub fn search_contents(
         }
     } else {
         for path in paths {
-            for result in WalkDir::new(path) {
+            let exclude_matcher = build_exclude_matcher(path, &ops.exclude_patterns);
+
+            for result in WalkDir::new(path).into_iter().filter_entry(|entry| {
+                !is_excluded_path(&exclude_matcher, entry.path(), entry.file_type().is_dir())
+            }) {
                 if must_stop.load(Ordering::Relaxed) {
                     return ContentResults::default();
                 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,6 +15,7 @@
     "fetching": "Loading...",
     "submit": "submit",
     "addHeader": "Add Header",
+    "addPattern": "Add Pattern",
     "key": "Key",
     "value": "Value",
     "success": "Success",
@@ -232,6 +233,10 @@
         "language": {
           "label": "Language",
           "desc": "Set the language of the app."
+        },
+        "file_exclude_patterns": {
+          "label": "File exclusion list",
+          "desc": "Exclude matching files and folders from the explorer and search. One gitignore-style pattern per line."
         }
       },
       "desc": "Common settings for the application."

--- a/locales/es.json
+++ b/locales/es.json
@@ -15,6 +15,7 @@
     "fetching": "Cargando...",
     "submit": "Presentar",
     "addHeader": "Añadir Header",
+    "addPattern": "Añadir patrón",
     "key": "Claves",
     "value": "Valor",
     "success": "Éxito",
@@ -194,6 +195,10 @@
         "language": {
           "label": "Idioma",
           "desc": "Establecer el idioma de la aplicación."
+        },
+        "file_exclude_patterns": {
+          "label": "Lista de exclusión de archivos",
+          "desc": "Excluir archivos y carpetas coincidentes del explorador y la búsqueda. Un patrón tipo gitignore por línea."
         }
       },
       "desc": "Configuración universal de la aplicación."

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -15,6 +15,7 @@
     "fetching": "chargement...",
     "submit": "Soumission",
     "addHeader": "Ajouter Header",
+    "addPattern": "Ajouter un motif",
     "key": "Touches",
     "value": "Valeur",
     "success": "Succès",
@@ -191,6 +192,10 @@
         "language": {
           "label": "Langue",
           "desc": "Choisir la langue de l'application."
+        },
+        "file_exclude_patterns": {
+          "label": "Liste d'exclusion de fichiers",
+          "desc": "Exclure les fichiers et dossiers correspondants de l'explorateur et de la recherche. Un motif de type gitignore par ligne."
         }
       },
       "desc": "Paramètres universels de l'application."

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -15,6 +15,7 @@
     "fetching": "読み込み中...",
     "submit": "送信",
     "addHeader": "Headerを追加",
+    "addPattern": "パターンを追加",
     "key": "キー",
     "value": "値",
     "success": "成功",
@@ -199,6 +200,10 @@
         "language": {
           "label": "言語",
           "desc": "アプリの言語を設定します。"
+        },
+        "file_exclude_patterns": {
+          "label": "ファイル除外リスト",
+          "desc": "エクスプローラーと検索から一致するファイルやフォルダーを除外します。1 行に 1 つの gitignore 形式のパターンを入力します。"
         }
       },
       "desc": "アプリケーションの共通設定。"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -15,6 +15,7 @@
     "fetching": "加载中...",
     "submit": "提交",
     "addHeader": "添加 Header",
+    "addPattern": "添加规则",
     "key": "键",
     "value": "值",
     "success": "成功",
@@ -230,6 +231,10 @@
         "language": {
           "label": "语言",
           "desc": "设置应用的语言。"
+        },
+        "file_exclude_patterns": {
+          "label": "文件排除列表",
+          "desc": "从侧边栏和搜索中排除匹配的文件或目录。每行一个类似 .gitignore 的规则。"
         }
       }
     },


### PR DESCRIPTION
-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

issue: Closes #1133

## Summary

引入了全局文件/目录排除列表功能（设置->通用->其他），支持类似 `.gitignore` 规则格式。

对原本代码功能的改动：原先 `filesys.ts` 与 `FileSystemAdapter.tsx` 中读取目录使用的是 `@tauri-apps/plugin-fs` 的 `readDir` 方法，而搜索逻辑在 Rust 侧执行，那可能要在两端各自实现一套过滤逻辑，行为可能不一致。所以我改成了调用 Tauri 后端命令 `open_folder_async`。把文件过滤、类型识别与排序集中在 Rust 侧处理。另外出于性能考虑，在 explorer 读取阶段提前过滤也减少返回给前端的无效条目。

## How did you test this change?

1. **单元测试验证**：
   - 补充并运行了前端测试 `file-exclude.test.ts`，验证了规则文本规范化（换行符/空格处理）及配置变更检测的准确性。
   - 在 Rust 侧 `fc.rs` 与 `manager.rs` 中添加了单元测试，验证了通配符（`*.tmp`）、目录匹配（`build/`）及白名单反转（`!keep.tmp`）的算法正确性。
   - 
2. **手动逻辑与 UI 交互验证**：
   - 在设置页面中添加排除规则，确认设置即时生效，侧边栏中的匹配文件/目录被隐藏。
   - 执行文件名全局搜索与内容搜索，确认排除的文件及目录内容不会出现在搜索结果列表中。