### PR TITLE
fix(desktop): prevent explorer flicker during rename validation

### DIFF
--- a/apps/desktop/src/components/Explorer/styles.ts
+++ b/apps/desktop/src/components/Explorer/styles.ts
@@ -8,7 +8,8 @@ export const Container = styled.div`
   overflow: auto;
   font-size: 0.8rem;
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     .explorer-bottom {
       display: flex;
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

修复如视频所示的闪烁现象：

https://github.com/user-attachments/assets/37f32179-8a91-403b-bb00-55c075ce6edc

重命名时的验证提示可能会出现在资源管理器 DOM 树之外。当光标 hover 在该提示上时，explorer 会失去 `:hover` 状态。

目前，explorer 的底部元素（“打开文件夹”按钮以及右边那个三个点的“最近打开的文件夹”展开菜单）只在光标 hover 于 explorer 上时显示。所以在重命名验证期间，底部元素会在隐藏和显示状态之间反复切换，导致explorer 布局发生变化，从而在文件行悬停状态、重命名输入框状态以及底部元素可见性之间引发闪烁现象。

修复方案是在 `:hover` 之外增加 `:focus-within` 规则，确保当焦点位于 explorer 内部时，底部元素保持可见。这样可以在重命名输入框获 focus 时保持布局稳定。

## How did you test this change?

手动验证：

https://github.com/user-attachments/assets/790714ee-4630-444b-87d1-532e5a3225c6
