### PR TITLE
fix: allow case-only renames on case-insensitive filesystems

### DIFF
--- a/apps/desktop/src/adapters/FileSystemAdapter.tsx
+++ b/apps/desktop/src/adapters/FileSystemAdapter.tsx
@@ -121,6 +121,10 @@ export const TauriFileSystemProvider: FC<FileSystemAdapterProps> = ({ children }
       return await invoke<boolean>('file_exists', { filePath })
     },
 
+    pathsReferToSameDirectoryEntry: async (path1: string, path2: string): Promise<boolean> => {
+      return await invoke<boolean>('paths_refer_to_same_directory_entry', { path1, path2 })
+    },
+
     moveFilesToTargetFolder: async (params: {
       files: string[]
       targetFolder: string

--- a/apps/desktop/src/helper/test/rename-conflict.test.ts
+++ b/apps/desktop/src/helper/test/rename-conflict.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { hasRenameConflict } from '../../../../../packages/interface/src/components/FileTree/rename-conflict'
+
+describe('hasRenameConflict', () => {
+  it('returns false when the path is unchanged', async () => {
+    const fileExists = vi.fn().mockResolvedValue(true)
+    const pathsReferToSameDirectoryEntry = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      hasRenameConflict({
+        currentPath: '/docs/Javascript',
+        candidatePath: '/docs/Javascript',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(false)
+
+    expect(fileExists).not.toHaveBeenCalled()
+    expect(pathsReferToSameDirectoryEntry).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the candidate path does not exist', async () => {
+    const fileExists = vi.fn().mockResolvedValue(false)
+    const pathsReferToSameDirectoryEntry = vi.fn()
+
+    await expect(
+      hasRenameConflict({
+        currentPath: '/docs/Javascript',
+        candidatePath: '/docs/TypeScript',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(false)
+
+    expect(pathsReferToSameDirectoryEntry).not.toHaveBeenCalled()
+  })
+
+  it('returns false for a case-only rename that resolves to the same directory entry', async () => {
+    // Windows/macOS case-insensitive filesystems: "JavaScript" resolves to the
+    // existing "Javascript" directory, so fileExists reports a collision even
+    // though it is the node itself.
+    const fileExists = vi.fn().mockResolvedValue(true)
+    const pathsReferToSameDirectoryEntry = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      hasRenameConflict({
+        currentPath: 'D:\\docs\\Javascript',
+        candidatePath: 'D:\\docs\\JavaScript',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(false)
+
+    expect(pathsReferToSameDirectoryEntry).toHaveBeenCalledWith(
+      'D:\\docs\\Javascript',
+      'D:\\docs\\JavaScript',
+    )
+  })
+
+  it('returns false for a case-only rename of a file (not just directories)', async () => {
+    // Same case-insensitive filesystem behavior applies to files: renaming
+    // javascript.md -> JavaScript.md resolves to the file itself.
+    const fileExists = vi.fn().mockResolvedValue(true)
+    const pathsReferToSameDirectoryEntry = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      hasRenameConflict({
+        currentPath: 'D:\\docs\\javascript.md',
+        candidatePath: 'D:\\docs\\JavaScript.md',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it('returns true when a different file already occupies the candidate path', async () => {
+    // Case-sensitive filesystems (Linux): renaming foo -> FOO while a separate
+    // FOO exists must still be reported as a conflict to avoid overwriting it.
+    // A hard link at the candidate path is also a different directory entry.
+    const fileExists = vi.fn().mockResolvedValue(true)
+    const pathsReferToSameDirectoryEntry = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      hasRenameConflict({
+        currentPath: '/docs/Javascript',
+        candidatePath: '/docs/JavaScript',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(true)
+  })
+
+  it('reduces to a plain existence check for an empty currentPath (new-file creation)', async () => {
+    // New nodes have no path yet; there is no "self" to exclude. The desktop
+    // backend returns false from paths_refer_to_same_directory_entry when
+    // either path does not exist, so any existing candidate is a conflict.
+    const fileExists = vi.fn().mockResolvedValue(true)
+    const pathsReferToSameDirectoryEntry = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      hasRenameConflict({
+        currentPath: '',
+        candidatePath: '/docs/JavaScript',
+        fileExists,
+        pathsReferToSameDirectoryEntry,
+      }),
+    ).resolves.toBe(true)
+
+    expect(pathsReferToSameDirectoryEntry).toHaveBeenCalledWith('', '/docs/JavaScript')
+  })
+})

--- a/apps/web/adapters/FileSystemAdapter.tsx
+++ b/apps/web/adapters/FileSystemAdapter.tsx
@@ -59,6 +59,10 @@ export const WebFileSystemProvider: FC<FileSystemAdapterProps> = ({ children, re
       return false
     },
 
+    pathsReferToSameDirectoryEntry: async (path1: string, path2: string): Promise<boolean> => {
+      return path1 === path2
+    },
+
     moveFilesToTargetFolder: async (): Promise<Array<MoveFileInfo>> => {
       return []
     },

--- a/packages/interface/src/components/FileTree/FileNode.tsx
+++ b/packages/interface/src/components/FileTree/FileNode.tsx
@@ -11,6 +11,7 @@ import {
 } from './file-mutation'
 import { moveFileNode } from './file-operator'
 import NewFileInput from './NewFileInput'
+import { hasRenameConflict } from './rename-conflict'
 import { NodeContainer } from './styles'
 import { SimpleTree } from './types'
 import { getFileNameFromPath } from './verify-file-name'
@@ -101,6 +102,7 @@ function FileNode({
     createFolder,
     writeFile,
     fileExists,
+    pathsReferToSameDirectoryEntry,
     revealInFolder,
   } = useFileSystem()
 
@@ -203,7 +205,14 @@ function FileNode({
       lease.protectPaths(protection.paths)
       lease.protectPaths([nextPath])
 
-      if (target.path !== nextPath && (await fileExists(nextPath))) {
+      if (
+        await hasRenameConflict({
+          currentPath: target.path,
+          candidatePath: nextPath,
+          fileExists,
+          pathsReferToSameDirectoryEntry,
+        })
+      ) {
         toast.error('File already exists')
         return
       }

--- a/packages/interface/src/components/FileTree/NewFileInput.tsx
+++ b/packages/interface/src/components/FileTree/NewFileInput.tsx
@@ -3,6 +3,7 @@ import { Input, Tooltip } from 'zens'
 import type { IFile } from '../../types/file'
 import { useFileSystem } from '../../contexts/FileSystemContext'
 import { isMdFile, unVerifiedFileNameChars, verifyFileName } from './verify-file-name'
+import { hasRenameConflict } from './rename-conflict'
 
 const NewFileInput = (
   props: HTMLAttributes<HTMLInputElement> & {
@@ -26,7 +27,7 @@ const NewFileInput = (
     ...otherProps
   } = props
 
-  const { pathJoin, fileExists } = useFileSystem()
+  const { pathJoin, fileExists, pathsReferToSameDirectoryEntry } = useFileSystem()
 
   const InvalidTextMap = {
     same: createType === 'file' ? 'has same file' : 'has same folder',
@@ -107,9 +108,17 @@ const NewFileInput = (
           const fileInfo = await getFileInfo(fileName)
 
           if (fileInfo.path) {
-            const exists = await fileExists(fileInfo.path)
+            // For newly created nodes fileNode.path is unset; an empty currentPath
+            // can never be the same file as the candidate, so this degrades to a
+            // plain existence check.
+            const conflict = await hasRenameConflict({
+              currentPath: fileNode.path ?? '',
+              candidatePath: fileInfo.path,
+              fileExists,
+              pathsReferToSameDirectoryEntry,
+            })
 
-            if (exists) {
+            if (conflict) {
               setInvalidText(InvalidTextMap.same)
               setInvalidState(true)
             } else {
@@ -121,7 +130,7 @@ const NewFileInput = (
 
       verifing.current = false
     },
-    [getFileInfo, fileExists],
+    [getFileInfo, fileExists, pathsReferToSameDirectoryEntry, fileNode],
   )
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(

--- a/packages/interface/src/components/FileTree/rename-conflict.ts
+++ b/packages/interface/src/components/FileTree/rename-conflict.ts
@@ -1,0 +1,28 @@
+export interface RenameConflictOptions {
+  /** Current path of the node being renamed. */
+  currentPath: string
+  /** Path the node would have after the rename. */
+  candidatePath: string
+  fileExists: (path: string) => Promise<boolean>
+  pathsReferToSameDirectoryEntry: (path1: string, path2: string) => Promise<boolean>
+}
+
+/**
+ * Whether renaming `currentPath` to `candidatePath` would collide with a
+ * different existing file.
+ *
+ * On case-insensitive filesystems, a case-only rename
+ * like `s` -> `S` makes `fileExists(candidatePath)` return
+ * true because the candidate resolves to the node itself. That is not a
+ * conflict, so the collision is only real when the two paths are not aliases
+ * of the same directory entry. Directory-entry identity (rather than plain
+ * inode identity) is used so a hard link at the candidate path still counts
+ * as a conflict.
+ */
+export async function hasRenameConflict(options: RenameConflictOptions): Promise<boolean> {
+  const { currentPath, candidatePath, fileExists, pathsReferToSameDirectoryEntry } = options
+
+  if (currentPath === candidatePath) return false
+  if (!(await fileExists(candidatePath))) return false
+  return !(await pathsReferToSameDirectoryEntry(currentPath, candidatePath))
+}

--- a/packages/interface/src/contexts/FileSystemContext.tsx
+++ b/packages/interface/src/contexts/FileSystemContext.tsx
@@ -37,6 +37,8 @@ export interface FileSystemContextValue {
   isDir: (path: string) => Promise<boolean>
   /** Check if a file exists */
   fileExists: (filePath: string) => Promise<boolean>
+  /** Check if two paths are case/Unicode aliases of the same directory entry (not merely hard links to the same file) */
+  pathsReferToSameDirectoryEntry: (path1: string, path2: string) => Promise<boolean>
   /** Move files to target folder */
   moveFilesToTargetFolder: (params: {
     files: string[]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.
-->

<!-- Language suggestions / 语言建议 -->
<!--  You can use english to describe. -->
<!-- 你可以使用中文来描述 -->

-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

在文件名大小写不敏感的系统上（如 Windows）重命名文件或目录时，如果只是修改字母大小写，比如 "s" -> "S"，则没有办法重命名成功，应用会保持原名不变。

具体原因是如果已存在名为 `s` 的文件或目录，调用 `fileExists("S")` 会返回 `true`，因为操作系统将这两个路径解析为同一个目录项。原有的重命名检查逻辑将所有 `fileExists(candidatePath) === true` 的情况都视为名称冲突，从而导致用户无法修改文件名的大小写。

解决方案是引入 `hasRenameConflict()` 函数，首先检查目标路径是否指向与当前路径相同的目录项（通过 `pathsReferToSameDirectoryEntry` 实现）。如果指向相同项，则该重命名操作仅涉及同一文件的大小写变更，不构成冲突。

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

- 添加 `rename-conflict.test.ts` 单元测试，并运行测试通过
- 手动测试：Windows 平台仅更改文件或目录名大小写，验证重命名成功
- 手动测试：在已有 s.md 的情况下，试图重命名另一个文件为 S.md，或创建一个新的文件 S.md，验证出现 has same file/folder 的提示

