### PR TITLE
feat(install): detect distro to install deb/rpm, rework download docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,29 +65,19 @@ At present, MarkFlowy needs about 3 - 6 months to perform reconstruction, which 
 
 ## Download
 
-Available for Linux, macOS and Windows.
+Available for Windows, macOS and Linux, from the [latest release](https://github.com/drl990114/MarkFlowy/releases/latest).
 
-### Linux installer
+### Windows
 
-On Linux, you can download and run `scripts/install-linux.sh` directly:
+Download and run one of the x64 builds:
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
-sh install-linux.sh
-```
+- `MarkFlowy_v<version>_x64-setup.exe` or `MarkFlowy_v<version>_x64.msi` — installer.
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — same, with the WebView2 runtime bundled.
+- `MarkFlowy_v<version>_x64_portable.zip` — unpack and run, no installation.
 
-If `curl` is unavailable, use `wget` instead:
+### macOS
 
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-The script downloads the AppImage for your architecture, installs it to `~/.local/share/markflowy`, and creates the `~/.local/bin/markflowy` command. To uninstall:
-
-```sh
-sh install-linux.sh --uninstall
-```
+Download `MarkFlowy_v<version>_aarch64.dmg` (Apple silicon) or `MarkFlowy_v<version>_x64.dmg` (Intel).
 
 > [!NOTE]
 > Because of Apple’s security policy restrictions on software without developer certification, the **macOS aarch64** version cannot be downloaded and used directly. You can ignore the limit by doing the following:
@@ -96,7 +86,29 @@ sh install-linux.sh --uninstall
 > - Run `xattr -cr MarkFlowy.app` and open the app again
 > - Please make sure you download from `github releases`.
 
-You can download it from [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases).
+### Linux
+
+x86_64 only for now.
+
+#### Flatpak
+
+On [FlatPark](https://flatpark.org) — [app page](https://flatpark.org/apps/io.github.drl990114.MarkFlowy):
+
+```sh
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.drl990114.MarkFlowy
+```
+
+#### Install script
+
+Installs the `.deb` or `.rpm` for your distribution, or the AppImage if it is not recognized:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
+sh install-linux.sh
+```
+
+Use `wget -O install-linux.sh <url>` if `curl` is unavailable. Add `--appimage` to force the AppImage, or `--uninstall` to remove MarkFlowy.
 
 ## Why
 

--- a/README.src.md
+++ b/README.src.md
@@ -102,52 +102,138 @@ At present, MarkFlowy needs about 3 - 6 months to perform reconstruction, which 
 
 ## ${en:'Download', zh:'下载', ja:'ダウンロード'}
 
-Available for Linux, macOS and Windows.<!--en-->
-支持平台 Linux, macOS 和 Windows.<!--zh-->
-Linux、macOS、Windows向けに利用可能です。<!--ja-->
-
-### ${en:'Linux installer', zh:'Linux 安装脚本', ja:'Linux インストールスクリプト'}
-
-${en:'On Linux, you can download and run `scripts/install-linux.sh` directly:', zh:'在 Linux 上，你可以直接下载并运行 `scripts/install-linux.sh`：', ja:'Linux では、`scripts/install-linux.sh` を直接ダウンロードして実行できます。'}
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
-sh install-linux.sh
-```
-
-${en:'If `curl` is unavailable, use `wget` instead:', zh:'如果没有 `curl`，可以改用 `wget`：', ja:'`curl` が利用できない場合は、代わりに `wget` を使用します。'}
-
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-${en:'The script downloads the AppImage for your architecture, installs it to `~/.local/share/markflowy`, and creates the `~/.local/bin/markflowy` command. To uninstall:', zh:'脚本会下载适配当前架构的 AppImage，安装到 `~/.local/share/markflowy`，并创建 `~/.local/bin/markflowy` 命令。卸载可执行：', ja:'このスクリプトは現在のアーキテクチャに対応する AppImage をダウンロードし、`~/.local/share/markflowy` にインストールして、`~/.local/bin/markflowy` コマンドを作成します。アンインストールするには:'}
-
-```sh
-sh install-linux.sh --uninstall
-```
-
-> [!NOTE]
+Available for Windows, macOS and Linux, from the [latest release](https://github.com/drl990114/MarkFlowy/releases/latest).<!--en-->
+<!--en-->
+### Windows<!--en-->
+<!--en-->
+Download and run one of the x64 builds:<!--en-->
+<!--en-->
+- `MarkFlowy_v<version>_x64-setup.exe` or `MarkFlowy_v<version>_x64.msi` — installer.<!--en-->
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — same, with the WebView2 runtime bundled.<!--en-->
+- `MarkFlowy_v<version>_x64_portable.zip` — unpack and run, no installation.<!--en-->
+<!--en-->
+### macOS<!--en-->
+<!--en-->
+Download `MarkFlowy_v<version>_aarch64.dmg` (Apple silicon) or `MarkFlowy_v<version>_x64.dmg` (Intel).<!--en-->
+<!--en-->
+> [!NOTE]<!--en-->
 > Because of Apple’s security policy restrictions on software without developer certification, the **macOS aarch64** version cannot be downloaded and used directly. You can ignore the limit by doing the following:<!--en-->
 > - Open your terminal<!--en-->
 > - Go to the `Applications` directory. .e.g `/Applications`.<!--en-->
 > - Run `xattr -cr MarkFlowy.app` and open the app again<!--en-->
 > - Please make sure you download from `github releases`.<!--en-->
-> 因为苹果安全策略对于没有开发者认证软件的限制，导致 **macOS aarch64** 版本无法直接安装. 你可以通过一下步骤忽略该限制:<!--zh-->
+<!--en-->
+### Linux<!--en-->
+<!--en-->
+x86_64 only for now.<!--en-->
+<!--en-->
+#### Flatpak<!--en-->
+<!--en-->
+On [FlatPark](https://flatpark.org) — [app page](https://flatpark.org/apps/io.github.drl990114.MarkFlowy):<!--en-->
+<!--en-->
+```sh<!--en-->
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo<!--en-->
+flatpak install flatpark io.github.drl990114.MarkFlowy<!--en-->
+```<!--en-->
+<!--en-->
+#### Install script<!--en-->
+<!--en-->
+Installs the `.deb` or `.rpm` for your distribution, or the AppImage if it is not recognized:<!--en-->
+<!--en-->
+```sh<!--en-->
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh<!--en-->
+sh install-linux.sh<!--en-->
+```<!--en-->
+<!--en-->
+Use `wget -O install-linux.sh <url>` if `curl` is unavailable. Add `--appimage` to force the AppImage, or `--uninstall` to remove MarkFlowy.<!--en-->
+支持 Windows、macOS 和 Linux，可从 [latest release](https://github.com/drl990114/MarkFlowy/releases/latest) 下载。<!--zh-->
+<!--zh-->
+### Windows<!--zh-->
+<!--zh-->
+下载并运行任意一个 x64 安装包：<!--zh-->
+<!--zh-->
+- `MarkFlowy_v<version>_x64-setup.exe` 或 `MarkFlowy_v<version>_x64.msi` — 安装程序。<!--zh-->
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — 同上，内置 WebView2 运行时。<!--zh-->
+- `MarkFlowy_v<version>_x64_portable.zip` — 解压即用，无需安装。<!--zh-->
+<!--zh-->
+### macOS<!--zh-->
+<!--zh-->
+下载 `MarkFlowy_v<version>_aarch64.dmg`（Apple silicon）或 `MarkFlowy_v<version>_x64.dmg`（Intel）。<!--zh-->
+<!--zh-->
+> [!NOTE]<!--zh-->
+> 因为苹果安全策略对于没有开发者认证软件的限制，导致 **macOS aarch64** 版本无法直接安装。你可以通过以下步骤忽略该限制：<!--zh-->
 > - 打开终端<!--zh-->
 > - 进入到 `应用` 的目录下. 例如 `/Applications`.<!--zh-->
 > - 执行 `xattr -cr MarkFlowy.app` 然后打开 app 即可<!--zh-->
 > - 请确保下载来源为 `github releases`。<!--zh-->
+<!--zh-->
+### Linux<!--zh-->
+<!--zh-->
+目前仅提供 x86_64 版本。<!--zh-->
+<!--zh-->
+#### Flatpak<!--zh-->
+<!--zh-->
+已上架 [FlatPark](https://flatpark.org) — [应用页面](https://flatpark.org/apps/io.github.drl990114.MarkFlowy)：<!--zh-->
+<!--zh-->
+```sh<!--zh-->
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo<!--zh-->
+flatpak install flatpark io.github.drl990114.MarkFlowy<!--zh-->
+```<!--zh-->
+<!--zh-->
+#### 安装脚本<!--zh-->
+<!--zh-->
+按发行版安装 `.deb` 或 `.rpm`，无法识别发行版时安装 AppImage：<!--zh-->
+<!--zh-->
+```sh<!--zh-->
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh<!--zh-->
+sh install-linux.sh<!--zh-->
+```<!--zh-->
+<!--zh-->
+没有 `curl` 时可用 `wget -O install-linux.sh <url>`。加 `--appimage` 强制使用 AppImage，加 `--uninstall` 卸载。<!--zh-->
+Windows、macOS、Linux 向けに利用可能です。[latest release](https://github.com/drl990114/MarkFlowy/releases/latest) からダウンロードできます。<!--ja-->
+<!--ja-->
+### Windows<!--ja-->
+<!--ja-->
+x64 ビルドのいずれかをダウンロードして実行します。<!--ja-->
+<!--ja-->
+- `MarkFlowy_v<version>_x64-setup.exe` または `MarkFlowy_v<version>_x64.msi` — インストーラー。<!--ja-->
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — 同上、WebView2 ランタイム同梱。<!--ja-->
+- `MarkFlowy_v<version>_x64_portable.zip` — 展開してそのまま実行、インストール不要。<!--ja-->
+<!--ja-->
+### macOS<!--ja-->
+<!--ja-->
+`MarkFlowy_v<version>_aarch64.dmg`（Apple silicon）または `MarkFlowy_v<version>_x64.dmg`（Intel）をダウンロードします。<!--ja-->
+<!--ja-->
+> [!NOTE]<!--ja-->
 > Appleのセキュリティポリシーにより、開発者認証のないソフトウェアは**macOS aarch64**版を直接ダウンロードして使用できません。以下の手順で制限を回避できます。<!--ja-->
 > - terminal を開く<!--ja-->
 > - `Applications` ディレクトリに移動します。例: `/Applications`。<!--ja-->
 > - `xattr -cr MarkFlowy.app` を実行し、再度アプリを開きます。<!--ja-->
 > - `github releases` からダウンロードしてください。<!--ja-->
-
-You can download it from [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases).<!--en-->
-你可以通过 [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases) 下载。<!--zh-->
-[GitHub Releases](https://github.com/drl990114/MarkFlowy/releases) からダウンロードできます。<!--ja-->
+<!--ja-->
+### Linux<!--ja-->
+<!--ja-->
+現在は x86_64 のみ提供しています。<!--ja-->
+<!--ja-->
+#### Flatpak<!--ja-->
+<!--ja-->
+[FlatPark](https://flatpark.org) で公開しています — [アプリページ](https://flatpark.org/apps/io.github.drl990114.MarkFlowy):<!--ja-->
+<!--ja-->
+```sh<!--ja-->
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo<!--ja-->
+flatpak install flatpark io.github.drl990114.MarkFlowy<!--ja-->
+```<!--ja-->
+<!--ja-->
+#### インストールスクリプト<!--ja-->
+<!--ja-->
+ディストリビューションに応じて `.deb` または `.rpm` をインストールし、判別できない場合は AppImage をインストールします。<!--ja-->
+<!--ja-->
+```sh<!--ja-->
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh<!--ja-->
+sh install-linux.sh<!--ja-->
+```<!--ja-->
+<!--ja-->
+`curl` が利用できない場合は `wget -O install-linux.sh <url>` を使用します。`--appimage` を付けると AppImage を強制的にインストールし、`--uninstall` でアンインストールします。<!--ja-->
 
 ## ${en:'Why', zh:'为什么开发', ja:'動機'}
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,38 +58,50 @@
 
 ## 下载
 
-支持平台 Linux, macOS 和 Windows.
+支持 Windows、macOS 和 Linux，可从 [latest release](https://github.com/drl990114/MarkFlowy/releases/latest) 下载。
 
-### Linux 安装脚本
+### Windows
 
-在 Linux 上，你可以直接下载并运行 `scripts/install-linux.sh`：
+下载并运行任意一个 x64 安装包：
+
+- `MarkFlowy_v<version>_x64-setup.exe` 或 `MarkFlowy_v<version>_x64.msi` — 安装程序。
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — 同上，内置 WebView2 运行时。
+- `MarkFlowy_v<version>_x64_portable.zip` — 解压即用，无需安装。
+
+### macOS
+
+下载 `MarkFlowy_v<version>_aarch64.dmg`（Apple silicon）或 `MarkFlowy_v<version>_x64.dmg`（Intel）。
+
+> [!NOTE]
+> 因为苹果安全策略对于没有开发者认证软件的限制，导致 **macOS aarch64** 版本无法直接安装。你可以通过以下步骤忽略该限制：
+> - 打开终端
+> - 进入到 `应用` 的目录下. 例如 `/Applications`.
+> - 执行 `xattr -cr MarkFlowy.app` 然后打开 app 即可
+> - 请确保下载来源为 `github releases`。
+
+### Linux
+
+目前仅提供 x86_64 版本。
+
+#### Flatpak
+
+已上架 [FlatPark](https://flatpark.org) — [应用页面](https://flatpark.org/apps/io.github.drl990114.MarkFlowy)：
+
+```sh
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.drl990114.MarkFlowy
+```
+
+#### 安装脚本
+
+按发行版安装 `.deb` 或 `.rpm`，无法识别发行版时安装 AppImage：
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
 sh install-linux.sh
 ```
 
-如果没有 `curl`，可以改用 `wget`：
-
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-脚本会下载适配当前架构的 AppImage，安装到 `~/.local/share/markflowy`，并创建 `~/.local/bin/markflowy` 命令。卸载可执行：
-
-```sh
-sh install-linux.sh --uninstall
-```
-
-> [!NOTE]
-> 因为苹果安全策略对于没有开发者认证软件的限制，导致 **macOS aarch64** 版本无法直接安装. 你可以通过一下步骤忽略该限制:
-> - 打开终端
-> - 进入到 `应用` 的目录下. 例如 `/Applications`.
-> - 执行 `xattr -cr MarkFlowy.app` 然后打开 app 即可
-> - 请确保下载来源为 `github releases`。
-
-你可以通过 [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases) 下载。
+没有 `curl` 时可用 `wget -O install-linux.sh <url>`。加 `--appimage` 强制使用 AppImage，加 `--uninstall` 卸载。
 
 ## 为什么开发
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -65,29 +65,19 @@
 
 ## ダウンロード
 
-Linux、macOS、Windows向けに利用可能です。
+Windows、macOS、Linux 向けに利用可能です。[latest release](https://github.com/drl990114/MarkFlowy/releases/latest) からダウンロードできます。
 
-### Linux インストールスクリプト
+### Windows
 
-Linux では、`scripts/install-linux.sh` を直接ダウンロードして実行できます。
+x64 ビルドのいずれかをダウンロードして実行します。
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
-sh install-linux.sh
-```
+- `MarkFlowy_v<version>_x64-setup.exe` または `MarkFlowy_v<version>_x64.msi` — インストーラー。
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — 同上、WebView2 ランタイム同梱。
+- `MarkFlowy_v<version>_x64_portable.zip` — 展開してそのまま実行、インストール不要。
 
-`curl` が利用できない場合は、代わりに `wget` を使用します。
+### macOS
 
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-このスクリプトは現在のアーキテクチャに対応する AppImage をダウンロードし、`~/.local/share/markflowy` にインストールして、`~/.local/bin/markflowy` コマンドを作成します。アンインストールするには:
-
-```sh
-sh install-linux.sh --uninstall
-```
+`MarkFlowy_v<version>_aarch64.dmg`（Apple silicon）または `MarkFlowy_v<version>_x64.dmg`（Intel）をダウンロードします。
 
 > [!NOTE]
 > Appleのセキュリティポリシーにより、開発者認証のないソフトウェアは**macOS aarch64**版を直接ダウンロードして使用できません。以下の手順で制限を回避できます。
@@ -96,7 +86,29 @@ sh install-linux.sh --uninstall
 > - `xattr -cr MarkFlowy.app` を実行し、再度アプリを開きます。
 > - `github releases` からダウンロードしてください。
 
-[GitHub Releases](https://github.com/drl990114/MarkFlowy/releases) からダウンロードできます。
+### Linux
+
+現在は x86_64 のみ提供しています。
+
+#### Flatpak
+
+[FlatPark](https://flatpark.org) で公開しています — [アプリページ](https://flatpark.org/apps/io.github.drl990114.MarkFlowy):
+
+```sh
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.drl990114.MarkFlowy
+```
+
+#### インストールスクリプト
+
+ディストリビューションに応じて `.deb` または `.rpm` をインストールし、判別できない場合は AppImage をインストールします。
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
+sh install-linux.sh
+```
+
+`curl` が利用できない場合は `wget -O install-linux.sh <url>` を使用します。`--appimage` を付けると AppImage を強制的にインストールし、`--uninstall` でアンインストールします。
 
 ## 動機
 

--- a/docs/en/intro.md
+++ b/docs/en/intro.md
@@ -13,29 +13,19 @@ Currently, MarkFlowy is in the beta stage, and it is recommended to use it with 
 
 ## Download
 
-Available for Linux, macOS and Windows.
+Available for Windows, macOS and Linux, from the [latest release](https://github.com/drl990114/MarkFlowy/releases/latest).
 
-### Linux installer
+### Windows
 
-On Linux, you can download and run `scripts/install-linux.sh` directly:
+Download and run one of the x64 builds:
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
-sh install-linux.sh
-```
+- `MarkFlowy_v<version>_x64-setup.exe` or `MarkFlowy_v<version>_x64.msi` — installer.
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — same, with the WebView2 runtime bundled.
+- `MarkFlowy_v<version>_x64_portable.zip` — unpack and run, no installation.
 
-If `curl` is unavailable, use `wget` instead:
+### macOS
 
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-The script downloads the AppImage for your architecture, installs it to `~/.local/share/markflowy`, and creates the `~/.local/bin/markflowy` command. To uninstall:
-
-```sh
-sh install-linux.sh --uninstall
-```
+Download `MarkFlowy_v<version>_aarch64.dmg` (Apple silicon) or `MarkFlowy_v<version>_x64.dmg` (Intel).
 
 > [!NOTE]
 > Because of Apple’s security policy restrictions on software without developer certification, the **macOS aarch64** version cannot be downloaded and used directly. You can ignore the limit by doing the following:
@@ -44,7 +34,29 @@ sh install-linux.sh --uninstall
 > - Run `xattr -cr MarkFlowy.app` and open the app again
 > - Please make sure you download from `github releases`.
 
-You can download it from [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases).
+### Linux
+
+x86_64 only for now.
+
+#### Flatpak
+
+On [FlatPark](https://flatpark.org) — [app page](https://flatpark.org/apps/io.github.drl990114.MarkFlowy):
+
+```sh
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.drl990114.MarkFlowy
+```
+
+#### Install script
+
+Installs the `.deb` or `.rpm` for your distribution, or the AppImage if it is not recognized:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
+sh install-linux.sh
+```
+
+Use `wget -O install-linux.sh <url>` if `curl` is unavailable. Add `--appimage` to force the AppImage, or `--uninstall` to remove MarkFlowy.
 
 ## Why
 

--- a/docs/zh/intro.md
+++ b/docs/zh/intro.md
@@ -13,38 +13,50 @@
 
 ## 下载
 
-支持 Linux、macOS 和 Windows。
+支持 Windows、macOS 和 Linux，可从 [latest release](https://github.com/drl990114/MarkFlowy/releases/latest) 下载。
 
-### Linux 安装脚本
+### Windows
 
-在 Linux 上，你可以直接下载并运行 `scripts/install-linux.sh`：
+下载并运行任意一个 x64 安装包：
+
+- `MarkFlowy_v<version>_x64-setup.exe` 或 `MarkFlowy_v<version>_x64.msi` — 安装程序。
+- `MarkFlowy_v<version>_offline_installer_x64-setup.exe` / `.msi` — 同上，内置 WebView2 运行时。
+- `MarkFlowy_v<version>_x64_portable.zip` — 解压即用，无需安装。
+
+### macOS
+
+下载 `MarkFlowy_v<version>_aarch64.dmg`（Apple silicon）或 `MarkFlowy_v<version>_x64.dmg`（Intel）。
+
+> [!NOTE]
+> 因为苹果安全策略对于没有开发者认证软件的限制，导致 **macOS aarch64** 版本无法直接安装。你可以通过以下步骤忽略该限制：
+> - 打开终端
+> - 进入到 `应用` 的目录下. 例如 `/Applications`.
+> - 执行 `xattr -cr MarkFlowy.app` 然后打开 app 即可
+> - 请确保下载来源为 `github releases`。
+
+### Linux
+
+目前仅提供 x86_64 版本。
+
+#### Flatpak
+
+已上架 [FlatPark](https://flatpark.org) — [应用页面](https://flatpark.org/apps/io.github.drl990114.MarkFlowy)：
+
+```sh
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+flatpak install flatpark io.github.drl990114.MarkFlowy
+```
+
+#### 安装脚本
+
+按发行版安装 `.deb` 或 `.rpm`，无法识别发行版时安装 AppImage：
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh -o install-linux.sh
 sh install-linux.sh
 ```
 
-如果没有 `curl`，可以改用 `wget`：
-
-```sh
-wget -O install-linux.sh https://raw.githubusercontent.com/drl990114/MarkFlowy/main/scripts/install-linux.sh
-sh install-linux.sh
-```
-
-脚本会下载适配当前架构的 AppImage，安装到 `~/.local/share/markflowy`，并创建 `~/.local/bin/markflowy` 命令。卸载可执行：
-
-```sh
-sh install-linux.sh --uninstall
-```
-
-> [!NOTE]
-> 由于苹果对未获得开发者认证软件的安全策略限制，**macOS aarch64** 版本无法直接下载使用。你可以通过以下方式忽略限制：
-> - 打开终端
-> - 进入 `Applications` 目录，例如 `/Applications`
-> - 运行 `xattr -cr MarkFlowy.app` 然后重新打开应用
-> - 请确保从 `github releases` 下载。
-
-你可以从 [GitHub Releases](https://github.com/drl990114/MarkFlowy/releases) 下载。
+没有 `curl` 时可用 `wget -O install-linux.sh <url>`。加 `--appimage` 强制使用 AppImage，加 `--uninstall` 卸载。
 
 ## 为什么
 

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -2,7 +2,9 @@
 set -eu
 
 APP_NAME="MarkFlowy"
-DEFAULT_MANIFEST_URL="https://github.com/drl990114/MarkFlowy/releases/latest/download/install.json"
+PACKAGE_NAME="mark-flowy"
+RELEASE_BASE_URL="https://github.com/drl990114/MarkFlowy/releases"
+DEFAULT_MANIFEST_URL="$RELEASE_BASE_URL/latest/download/install.json"
 FALLBACK_MANIFEST_URL="https://drl990114.github.io/MarkFlowy/install.json"
 
 INSTALL_DIR="${MARKFLOWY_INSTALL_DIR:-${HOME:-}/.local/share/markflowy}"
@@ -27,14 +29,19 @@ usage() {
   cat <<'EOF'
 Install MarkFlowy for Linux.
 
+By default the script detects your distribution and installs the native
+package (.deb on Debian/Ubuntu, .rpm on Fedora/RHEL/openSUSE). On any other
+distribution it falls back to the AppImage.
+
 Usage:
-  sh install-linux.sh
-  sh install-linux.sh --uninstall
+  sh install-linux.sh              Detect the distribution and install
+  sh install-linux.sh --appimage   Always install the AppImage
+  sh install-linux.sh --uninstall  Remove MarkFlowy
 
 Environment:
   MARKFLOWY_MANIFEST_URL   Override updater manifest URL.
-  MARKFLOWY_DOWNLOAD_URL   Override AppImage download URL.
-  MARKFLOWY_INSTALL_DIR    Override app install directory.
+  MARKFLOWY_DOWNLOAD_URL   Override download URL (.deb, .rpm or AppImage).
+  MARKFLOWY_INSTALL_DIR    Override AppImage install directory.
   MARKFLOWY_BIN_DIR        Override command install directory.
 EOF
 }
@@ -153,10 +160,208 @@ detect_platform() {
       printf '%s\n' "linux"
       ;;
     aarch64 | arm64)
-      printf '%s\n' "linux-aarch64"
+      die "$APP_NAME does not publish Linux aarch64 builds yet"
       ;;
     *)
       die "unsupported Linux architecture: $machine"
+      ;;
+  esac
+}
+
+# Print `deb`, `rpm` or `appimage` based on /etc/os-release. ID is checked
+# before ID_LIKE so a derivative that declares both wins on its own family.
+detect_package_format() {
+  distro_ids=""
+
+  if [ -r /etc/os-release ]; then
+    distro_ids=$(
+      # shellcheck disable=SC1091
+      . /etc/os-release 2>/dev/null || true
+      printf '%s %s' "${ID:-}" "${ID_LIKE:-}"
+    )
+  fi
+
+  for distro_id in $distro_ids; do
+    case "$distro_id" in
+      debian | ubuntu | linuxmint | pop | elementary | zorin | kali | deepin | raspbian | neon | devuan | trisquel)
+        printf '%s\n' "deb"
+        return
+        ;;
+      fedora | rhel | centos | rocky | almalinux | ol | oracle | amzn | scientific | mageia | openmandriva | suse | opensuse | opensuse-leap | opensuse-tumbleweed | sled | sles)
+        printf '%s\n' "rpm"
+        return
+        ;;
+    esac
+  done
+
+  printf '%s\n' "appimage"
+}
+
+# Print the command prefix needed to gain root, or nothing when already root.
+# Returns non-zero when privileges cannot be obtained at all.
+detect_privilege_command() {
+  if [ "$(id -u 2>/dev/null || echo 1)" = "0" ]; then
+    return 0
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    printf '%s\n' "sudo"
+    return 0
+  fi
+
+  if command -v doas >/dev/null 2>&1; then
+    printf '%s\n' "doas"
+    return 0
+  fi
+
+  return 1
+}
+
+package_manager_available() {
+  case "$1" in
+    deb)
+      command -v dpkg >/dev/null 2>&1
+      ;;
+    rpm)
+      command -v dnf >/dev/null 2>&1 ||
+        command -v zypper >/dev/null 2>&1 ||
+        command -v yum >/dev/null 2>&1 ||
+        command -v rpm >/dev/null 2>&1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+install_deb() {
+  file=$1
+
+  if command -v apt-get >/dev/null 2>&1; then
+    if $privilege_command apt-get install -y "$file"; then
+      return 0
+    fi
+
+    err "apt-get failed, retrying with dpkg"
+  fi
+
+  if $privilege_command dpkg -i "$file"; then
+    return 0
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    say "Resolving missing dependencies..."
+
+    if $privilege_command apt-get install -f -y; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+install_rpm() {
+  file=$1
+
+  if command -v dnf >/dev/null 2>&1; then
+    $privilege_command dnf install -y "$file"
+  elif command -v zypper >/dev/null 2>&1; then
+    $privilege_command zypper --non-interactive install --allow-unsigned-rpm "$file"
+  elif command -v yum >/dev/null 2>&1; then
+    $privilege_command yum install -y "$file"
+  else
+    $privilege_command rpm -Uvh "$file"
+  fi
+}
+
+# Print dpkg's state word for the package, e.g. `installed`, `unpacked`,
+# `half-configured`, `config-files` or `not-installed`. Returns non-zero when
+# dpkg cannot be queried at all.
+deb_package_state() {
+  command -v dpkg-query >/dev/null 2>&1 || return 1
+
+  # `Status` is three words -- want, error flag and state -- so the state is
+  # everything after the last space.
+  deb_status=$(dpkg-query -W -f='${Status}' "$PACKAGE_NAME" 2>/dev/null || true)
+
+  [ -n "$deb_status" ] || return 1
+
+  printf '%s\n' "${deb_status##* }"
+}
+
+# True when the package is fully unpacked *and* configured. A package manager
+# can report success while leaving the package in some other state, so this is
+# what an install is verified against.
+package_installed() {
+  case "$1" in
+    deb)
+      [ "$(deb_package_state || true)" = "installed" ]
+      ;;
+    rpm)
+      command -v rpm >/dev/null 2>&1 && rpm -q "$PACKAGE_NAME" >/dev/null 2>&1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# True when dpkg/rpm knows about the package in any state at all, including a
+# half-installed one left behind by a failed install. Uninstall uses this, so
+# that a broken package still gets cleaned up.
+package_present() {
+  case "$1" in
+    deb)
+      deb_state=$(deb_package_state) || return 1
+      [ -n "$deb_state" ] && [ "$deb_state" != "not-installed" ]
+      ;;
+    rpm)
+      package_installed rpm
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# True when the package tooling is present, so a negative package_installed
+# result actually means something.
+package_state_is_knowable() {
+  case "$1" in
+    deb) command -v dpkg-query >/dev/null 2>&1 ;;
+    rpm) command -v rpm >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Remove an AppImage installed by an earlier run of this script. Returns
+# non-zero when there was nothing to remove.
+remove_appimage() {
+  [ -e "$APPIMAGE_PATH" ] || [ -e "$BIN_PATH" ] || return 1
+
+  rm -f "$BIN_PATH" "$APPIMAGE_PATH" "$APPIMAGE_PATH.sig"
+  rmdir "$INSTALL_DIR" 2>/dev/null || true
+}
+
+remove_package() {
+  case "$1" in
+    deb)
+      if command -v apt-get >/dev/null 2>&1; then
+        $privilege_command apt-get remove -y "$PACKAGE_NAME"
+      else
+        $privilege_command dpkg -r "$PACKAGE_NAME"
+      fi
+      ;;
+    rpm)
+      if command -v dnf >/dev/null 2>&1; then
+        $privilege_command dnf remove -y "$PACKAGE_NAME"
+      elif command -v zypper >/dev/null 2>&1; then
+        $privilege_command zypper --non-interactive remove "$PACKAGE_NAME"
+      elif command -v yum >/dev/null 2>&1; then
+        $privilege_command yum remove -y "$PACKAGE_NAME"
+      else
+        $privilege_command rpm -e "$PACKAGE_NAME"
+      fi
       ;;
   esac
 }
@@ -169,31 +374,145 @@ path_contains_bin_dir() {
 }
 
 uninstall() {
-  rm -f "$BIN_PATH" "$APPIMAGE_PATH" "$APPIMAGE_PATH.sig"
-  rmdir "$INSTALL_DIR" 2>/dev/null || true
-  say "Removed $APP_NAME from $INSTALL_DIR"
-  say "Removed command wrapper: $BIN_PATH"
+  removed=0
+  failed=0
+
+  for package_format in deb rpm; do
+    if package_present "$package_format"; then
+      if privilege_command=$(detect_privilege_command); then
+        say "Removing the $package_format package $PACKAGE_NAME..."
+
+        if remove_package "$package_format"; then
+          removed=1
+        else
+          err "failed to remove the $package_format package $PACKAGE_NAME"
+          failed=1
+        fi
+      else
+        err "root privileges are required to remove the $package_format package $PACKAGE_NAME"
+        failed=1
+      fi
+    fi
+  done
+
+  if remove_appimage; then
+    say "Removed the AppImage from $INSTALL_DIR"
+    say "Removed command wrapper: $BIN_PATH"
+    removed=1
+  fi
+
+  if [ "$failed" = "1" ]; then
+    return 1
+  fi
+
+  [ "$removed" = "1" ] || say "No $APP_NAME installation found."
 }
 
-case "${1:-}" in
-  -h | --help)
-    usage
-    exit 0
-    ;;
-  --uninstall)
-    [ -n "${HOME:-}" ] || die "HOME is not set"
-    uninstall
-    exit 0
-    ;;
-  "")
-    ;;
-  *)
-    usage >&2
-    exit 1
-    ;;
-esac
+install_appimage() {
+  url=$1
+  appimage_tmp="$tmp_dir/MarkFlowy.AppImage"
+
+  say "Downloading the $APP_NAME AppImage ${version:-latest}..."
+  download "$url" "$appimage_tmp"
+  chmod 0755 "$appimage_tmp"
+
+  mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+  mv -f "$appimage_tmp" "$APPIMAGE_PATH"
+
+  quoted_appimage=$(shell_quote "$APPIMAGE_PATH")
+  {
+    printf '%s\n' '#!/usr/bin/env sh'
+    printf 'exec %s "$@"\n' "$quoted_appimage"
+  } > "$BIN_PATH"
+  chmod 0755 "$BIN_PATH"
+
+  say ""
+  say "$APP_NAME ${version:-latest} installed."
+  say "AppImage: $APPIMAGE_PATH"
+  say "Command:  $BIN_PATH"
+
+  if ! path_contains_bin_dir; then
+    say ""
+    say "Add this directory to PATH before running markflowy:"
+    say "  export PATH=\"$BIN_DIR:\$PATH\""
+  else
+    say ""
+    say "Run: markflowy"
+  fi
+
+  say ""
+  say "If the AppImage cannot start, install FUSE for your distribution and try again."
+}
+
+install_package() {
+  format=$1
+  url=$2
+  package_tmp="$tmp_dir/markflowy.$format"
+
+  say "Downloading the $APP_NAME .$format package ${version:-latest}..."
+
+  if ! download "$url" "$package_tmp"; then
+    err "failed to download $url"
+    return 1
+  fi
+
+  say "Installing $package_tmp..."
+
+  case "$format" in
+    deb) install_deb "$package_tmp" ;;
+    rpm) install_rpm "$package_tmp" ;;
+  esac || return 1
+
+  # A package manager can exit 0 without the package ending up installed --
+  # `apt-get install -f` in particular is allowed to resolve a broken state by
+  # dropping the package it could not configure.
+  if package_state_is_knowable "$format" && ! package_installed "$format"; then
+    err "the package manager reported success but $PACKAGE_NAME is not installed"
+    return 1
+  fi
+
+  # An earlier run of this script may have left an AppImage behind, and its
+  # ~/.local/bin wrapper would shadow the command from the package.
+  if remove_appimage; then
+    say "Removed the AppImage left by an earlier run of this script."
+  fi
+
+  say ""
+  say "$APP_NAME ${version:-latest} installed."
+  say "Run: markflowy"
+}
+
+format=""
+action="install"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --appimage)
+      format="appimage"
+      ;;
+    --uninstall)
+      action="uninstall"
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 [ -n "${HOME:-}" ] || die "HOME is not set"
+
+privilege_command=""
+
+if [ "$action" = "uninstall" ]; then
+  uninstall || exit 1
+  exit 0
+fi
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/markflowy.XXXXXX")
 trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
@@ -201,51 +520,88 @@ trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
 platform=$(detect_platform)
 version=""
 manifest_url=""
+appimage_url=""
 
 if [ -n "${MARKFLOWY_DOWNLOAD_URL:-}" ]; then
-  download_url=$MARKFLOWY_DOWNLOAD_URL
+  if [ -z "$format" ]; then
+    case "$MARKFLOWY_DOWNLOAD_URL" in
+      *.deb) format="deb" ;;
+      *.rpm) format="rpm" ;;
+      *) format="appimage" ;;
+    esac
+  fi
+
+  deb_url=$MARKFLOWY_DOWNLOAD_URL
+  rpm_url=$MARKFLOWY_DOWNLOAD_URL
+
+  # Only an override that is actually an AppImage may be used as one. Reusing a
+  # .deb/.rpm override here would install the package file as `MarkFlowy.AppImage`
+  # when the package install fails.
+  if [ "$format" = "appimage" ]; then
+    appimage_url=$MARKFLOWY_DOWNLOAD_URL
+  fi
 else
   manifest_path="$tmp_dir/install.json"
 
   download_manifest "$manifest_path"
 
   version=$(extract_version "$manifest_path")
-  download_url=$(extract_platform_url "$manifest_path" "$platform")
+  appimage_url=$(extract_platform_url "$manifest_path" "$platform")
 
-  if [ -z "$download_url" ]; then
-    die "no AppImage URL found for platform '$platform' in $manifest_url"
+  [ -n "$version" ] || die "no version found in $manifest_url"
+
+  # Release assets are named MarkFlowy_v0.0.0_amd64.deb and
+  # MarkFlowy-0.0.0-1.x86_64.rpm, so both spellings of the version are needed.
+  version_tag=$version
+  case "$version_tag" in
+    v*) ;;
+    *) version_tag="v$version_tag" ;;
+  esac
+  version_number=${version_tag#v}
+
+  deb_url="$RELEASE_BASE_URL/download/$version_tag/${APP_NAME}_${version_tag}_amd64.deb"
+  rpm_url="$RELEASE_BASE_URL/download/$version_tag/${APP_NAME}-${version_number}-1.x86_64.rpm"
+fi
+
+if [ -z "$format" ]; then
+  format=$(detect_package_format)
+
+  if [ "$format" = "appimage" ]; then
+    say "Unrecognized distribution, using the AppImage."
+  elif ! package_manager_available "$format"; then
+    say "No .$format package manager found, using the AppImage."
+    format="appimage"
+  elif ! privilege_command=$(detect_privilege_command); then
+    say "Installing a .$format package needs root and neither sudo nor doas is available, using the AppImage."
+    format="appimage"
+  else
+    say "Detected a .$format based distribution."
   fi
 fi
 
-appimage_tmp="$tmp_dir/MarkFlowy.AppImage"
-
-say "Downloading $APP_NAME ${version:-latest}..."
-download "$download_url" "$appimage_tmp"
-chmod 0755 "$appimage_tmp"
-
-mkdir -p "$INSTALL_DIR" "$BIN_DIR"
-mv -f "$appimage_tmp" "$APPIMAGE_PATH"
-
-quoted_appimage=$(shell_quote "$APPIMAGE_PATH")
-{
-  printf '%s\n' '#!/usr/bin/env sh'
-  printf 'exec %s "$@"\n' "$quoted_appimage"
-} > "$BIN_PATH"
-chmod 0755 "$BIN_PATH"
-
-say ""
-say "$APP_NAME ${version:-latest} installed."
-say "AppImage: $APPIMAGE_PATH"
-say "Command:  $BIN_PATH"
-
-if ! path_contains_bin_dir; then
-  say ""
-  say "Add this directory to PATH before running markflowy:"
-  say "  export PATH=\"$BIN_DIR:\$PATH\""
-else
-  say ""
-  say "Run: markflowy"
+if [ "$format" != "appimage" ] && [ -z "$privilege_command" ]; then
+  privilege_command=$(detect_privilege_command) ||
+    die "root privileges are required to install a .$format package, or run with --appimage"
 fi
 
-say ""
-say "If the AppImage cannot start, install FUSE for your distribution and try again."
+package_url=""
+
+case "$format" in
+  deb) package_url=$deb_url ;;
+  rpm) package_url=$rpm_url ;;
+esac
+
+if [ -n "$package_url" ]; then
+  if ! install_package "$format" "$package_url"; then
+    [ -n "$appimage_url" ] ||
+      die "the .$format install failed and there is no AppImage to fall back to"
+
+    err "the .$format install failed, falling back to the AppImage"
+    format="appimage"
+  fi
+fi
+
+if [ "$format" = "appimage" ]; then
+  [ -n "$appimage_url" ] || die "no AppImage URL found for platform '$platform' in ${manifest_url:-MARKFLOWY_DOWNLOAD_URL}"
+  install_appimage "$appimage_url"
+fi


### PR DESCRIPTION
-   [x] I read the contributing guide
-   [x] I agree to follow the code of conduct

## Summary

Follow-up to #867, where the original problem was that the AppImage hit dependency
trouble on an older LTS. Two related changes:

**1. `scripts/install-linux.sh` now installs the package that fits the distribution.**

It previously always installed the AppImage. It now reads `/etc/os-release` and picks:

| Distribution | Installs |
| --- | --- |
| Debian, Ubuntu and derivatives | `.deb` via `apt-get` (falls back to `dpkg -i` + `apt-get -f install`) |
| Fedora, RHEL, openSUSE and derivatives | `.rpm` via `dnf` / `zypper` / `yum` / `rpm` |
| anything else, or no `/etc/os-release` | AppImage, exactly as before |

- `--appimage` forces the AppImage regardless of distribution.
- Installing a package needs root, so the script uses `sudo` (or `doas`). If it cannot
  get root, finds no package manager, or the package install fails, it says so and falls
  back to the AppImage.
- `--uninstall` now removes the package as well as the AppImage.
- After a package install the script verifies the package is actually installed rather
  than trusting the exit code, because `apt-get install -f` is allowed to resolve a broken
  state by dropping the very package it could not configure.
- A successful package install removes an AppImage left by an earlier run of this script,
  whose `~/.local/bin/markflowy` wrapper would otherwise shadow the command from the package.

`install.json` carries no deb/rpm URLs, so those are derived from the manifest version to
match the published asset names.

**2. The Download section of the docs is reorganised.**

It is now three sections instead of one Linux-centric block:

- **Windows** — the four x64 builds, including the portable zip.
- **macOS** — both disk images. The `xattr -cr` note moved here, where it actually applies;
  it previously sat under the Linux installer.
- **Linux** — Flatpak first, then the install script.

The Flatpak is on [FlatPark](https://flatpark.org)
([app page](https://flatpark.org/apps/io.github.drl990114.MarkFlowy)), as discussed in #867.
It brings its own runtime, so it covers the older distributions that started that issue.

> Disclosure: I maintain FlatPark. The package downloads the official `.deb` from GitHub
> Releases unmodified and does not rehost or patch anything. Happy to drop or reword this
> part of the PR if you would rather not point at it from the README.

The READMEs are generated from `README.src.md`, so all three languages were regenerated with
NRG 1.1; `nrg --check` is clean, so the drift-check workflow passes. `docs/en/intro.md` and
`docs/zh/intro.md` carry the same section and were updated by hand, since they are not part
of the NRG pipeline.

## How did you test this change?

**Shell portability** — the script parses cleanly under all three:

```sh
dash -n scripts/install-linux.sh
sh -n scripts/install-linux.sh
busybox ash -n scripts/install-linux.sh
```

**Distribution detection** — with a stubbed `/etc/os-release`, each of these resolves as
expected: `ubuntu`, `debian`, `linuxmint`, `deepin` → `deb`; `fedora`, `rocky`,
`opensuse-tumbleweed` → `rpm`; `arch`, `nixos`, `alpine`, `steamos`, and a missing
`/etc/os-release` → `appimage`. `ID` is checked before `ID_LIKE`, so a derivative that
declares both resolves on its own family.

**Install paths** — run against stub `apt-get` / `dpkg` / `dnf` / `sudo` on `PATH`, so
nothing was installed on the test machine. Verified: the deb and rpm paths invoke the right
package manager with the right file; a 404 package falls back to the AppImage; a package
manager that exits 0 without installing is caught and does not report success; the AppImage
install → `--uninstall` → `--uninstall` round trip is clean and the second one reports
nothing to remove.

**Download URLs** — both derived URLs resolve to the real v0.88.0 assets
(`MarkFlowy_v0.88.0_amd64.deb`, `MarkFlowy-0.88.0-1.x86_64.rpm`), and the package name
`mark-flowy` was read from the actual deb control file and rpm header rather than guessed.

**Not covered:** I have not run a real `sudo apt-get install` / `dnf install` of the package
on a clean Debian or Fedora machine — the package-manager invocations were exercised through
stubs only. Worth a real smoke test on one deb and one rpm distribution before this ships.
There are also no Linux aarch64 builds published, so the script now fails with a clear
message on aarch64 instead of the previous confusing "no AppImage URL found".
